### PR TITLE
Add currentEntity field to cloudscript context

### DIFF
--- a/Scripts/typings/PlayFab/CloudScript.d.ts
+++ b/Scripts/typings/PlayFab/CloudScript.d.ts
@@ -38,7 +38,7 @@ interface IPlayFabContext {
     playStreamEvent: PlayStreamModels.IBasePlayStreamEvent;
     playerProfile: IPlayFabPlayerProfile;
     triggeredByTask: ITriggeredByTask;
-    currentEntity?: EntityProfileBody;
+    currentEntity?: PlayFabProfilesModels.EntityProfileBody;
 }
 
 interface IPlayFabPlayerProfile {


### PR DESCRIPTION
The context field 'currentEntity' is set when calling cloud script with ExecuteEntityCloudScript. By adding this optional field to the type definitions we will be able to use it without false errors given by typescript transpiler.