### PR TITLE
Regenerate CloudScript typings to latest API specs and add Multiplayer API support

### DIFF
--- a/Scripts/typings/PlayFab/CloudScript.d.ts
+++ b/Scripts/typings/PlayFab/CloudScript.d.ts
@@ -77,6 +77,8 @@ interface IApiError {
 declare var server: IPlayFabServerAPI;
 /** Static object which allows access to PlayFab Entity API calls */
 declare var entity: IPlayFabEntityAPI;
+/** Static object which allows access to PlayFab Multiplayer API calls (includes Matchmaking, MultiplayerServer, Party, and Lobby) */
+declare var multiplayer: IPlayFabMultiplayerAPI;
 
 /** ServerAPI.Models as interfaces */
 declare namespace PlayFabServerModels {
@@ -132,6 +134,22 @@ declare namespace PlayFabServerModels {
         GenericId: GenericServiceId,
         /** PlayFabId of the user to link. */
         PlayFabId: string,
+    }
+
+    /**
+     * This API adds a contact email to the specified player's profile. If the player's profile already contains a contact
+     * email, it will update the contact email to the email address specified.
+     */
+    interface AddOrUpdateContactEmailRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The new contact email to associate with the player. */
+        EmailAddress: string,
+        /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
+        PlayFabId: string,
+    }
+
+    interface AddOrUpdateContactEmailResult {
     }
 
     /**
@@ -239,6 +257,8 @@ declare namespace PlayFabServerModels {
         PlayFabId?: string,
         /** The reason why this ban was applied. */
         Reason?: string,
+        /** The family type of the user that is included in the ban. */
+        UserFamilyType?: string,
     }
 
     /** Represents a single ban request. */
@@ -247,17 +267,17 @@ declare namespace PlayFabServerModels {
         DurationInHours?: number,
         /** IP address to be banned. May affect multiple players. */
         IPAddress?: string,
-        /** MAC address to be banned. May affect multiple players. */
-        MACAddress?: string,
         /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
         PlayFabId: string,
         /** The reason for this ban. Maximum 140 characters. */
         Reason?: string,
+        /** The family type of the user that should be included in the ban if applicable. May affect multiple players. */
+        UserFamilyType?: UserFamilyType,
     }
 
     /**
-     * The existence of each user will not be verified. When banning by IP or MAC address, multiple players may be affected, so
-     * use this feature with caution. Returns information about the new bans.
+     * The existence of each user will not be verified. When banning by IP, multiple players may be affected, so use this
+     * feature with caution. Returns information about the new bans.
      */
     interface BanUsersRequest {
         /** List of ban requests to be applied. Maximum 100. */
@@ -269,6 +289,13 @@ declare namespace PlayFabServerModels {
     interface BanUsersResult {
         /** Information on the bans that were applied */
         BanData?: BanInfo[],
+    }
+
+    interface BattleNetAccountPlayFabIdPair {
+        /** Unique Battle.net account identifier for a user. */
+        BattleNetAccountId?: string,
+        /** Unique PlayFab identifier for a user, or null if no PlayFab account is linked to the Battle.net account identifier. */
+        PlayFabId?: string,
     }
 
     /** A purchasable item from the item catalog */
@@ -414,7 +441,14 @@ declare namespace PlayFabServerModels {
         CharacterType?: string,
     }
 
+    type ChurnRiskLevel = "NoData"
+
+        | "LowRisk"
+        | "MediumRisk"
+        | "HighRisk";
+
     type CloudScriptRevisionOption = "Live"
+
         | "Latest"
         | "Specific";
 
@@ -457,14 +491,17 @@ declare namespace PlayFabServerModels {
     }
 
     type ContinentCode = "AF"
+
         | "AN"
         | "AS"
         | "EU"
         | "NA"
         | "OC"
-        | "SA";
+        | "SA"
+        | "Unknown";
 
     type CountryCode = "AF"
+
         | "AX"
         | "AL"
         | "DZ"
@@ -712,7 +749,8 @@ declare namespace PlayFabServerModels {
         | "EH"
         | "YE"
         | "ZM"
-        | "ZW";
+        | "ZW"
+        | "Unknown";
 
     /**
      * If SharedGroupId is specified, the service will attempt to create a group with that identifier, and will return an error
@@ -729,6 +767,7 @@ declare namespace PlayFabServerModels {
     }
 
     type Currency = "AED"
+
         | "AFN"
         | "ALL"
         | "AMD"
@@ -891,6 +930,13 @@ declare namespace PlayFabServerModels {
         | "ZMW"
         | "ZWD";
 
+    interface CustomPropertyDetails {
+        /** The custom property's name. */
+        Name?: string,
+        /** The custom property's value. */
+        Value?: any,
+    }
+
     /**
      * This function will delete the specified character from the list allowed by the user, and will also delete any inventory
      * or VC currently held by that character. It will NOT delete any statistics associated for this character, in order to
@@ -911,6 +957,40 @@ declare namespace PlayFabServerModels {
     }
 
     interface DeleteCharacterFromUserResult {
+    }
+
+    interface DeletedPropertyDetails {
+        /** The name of the property which was requested to be deleted. */
+        Name?: string,
+        /** Indicates whether or not the property was deleted. If false, no property with that name existed. */
+        WasDeleted: boolean,
+    }
+
+    /** Deletes custom properties for the specified player. The list of provided property names must be non-empty. */
+    interface DeletePlayerCustomPropertiesRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /**
+         * Optional field used for concurrency control. One can ensure that the delete operation will only be performed if the
+         * player's properties have not been updated by any other clients since the last version.
+         */
+        ExpectedPropertiesVersion?: number,
+        /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
+        PlayFabId: string,
+        /** A list of property names denoting which properties should be deleted. */
+        PropertyNames: string[],
+    }
+
+    interface DeletePlayerCustomPropertiesResult {
+        /** The list of properties requested to be deleted. */
+        DeletedProperties?: DeletedPropertyDetails[],
+        /** PlayFab unique identifier of the user whose properties were deleted. */
+        PlayFabId?: string,
+        /**
+         * Indicates the current version of a player's properties that have been set. This is incremented after updates and
+         * deletes. This version can be provided in update and delete calls for concurrency control.
+         */
+        PropertiesVersion: number,
     }
 
     /**
@@ -945,17 +1025,8 @@ declare namespace PlayFabServerModels {
         SharedGroupId: string,
     }
 
-    interface DeregisterGameRequest {
-        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
-        CustomTags?: { [key: string]: string | null },
-        /** Unique identifier for the Game Server Instance that is being deregistered. */
-        LobbyId: string,
-    }
-
-    interface DeregisterGameResponse {
-    }
-
     type EmailVerificationStatus = "Unverified"
+
         | "Pending"
         | "Confirmed";
 
@@ -1062,6 +1133,14 @@ declare namespace PlayFabServerModels {
         SpecificRevision?: number,
     }
 
+    type ExternalFriendSources = "None"
+
+        | "Steam"
+        | "Facebook"
+        | "Xbox"
+        | "Psn"
+        | "All";
+
     interface FacebookInstantGamesPlayFabIdPair {
         /** Unique Facebook Instant Games identifier for a user. */
         FacebookInstantGamesId?: string,
@@ -1077,17 +1156,23 @@ declare namespace PlayFabServerModels {
     }
 
     interface FriendInfo {
-        /** Available Facebook information (if the user and PlayFab friend are also connected in Facebook). */
+        /** Available Facebook information (if the user and connected Facebook friend both have PlayFab Accounts in the same title). */
         FacebookInfo?: UserFacebookInfo,
         /** PlayFab unique identifier for this friend. */
         FriendPlayFabId?: string,
-        /** Available Game Center information (if the user and PlayFab friend are also connected in Game Center). */
+        /**
+         * Available Game Center information (if the user and connected Game Center friend both have PlayFab Accounts in the same
+         * title).
+         */
         GameCenterInfo?: UserGameCenterInfo,
         /** The profile of the user, if requested. */
         Profile?: PlayerProfileModel,
-        /** Available PSN information, if the user and PlayFab friend are both connected to PSN. */
+        /**
+         * Available PlayStation :tm: Network information, if the user connected PlayStation :tm Network friend both have PlayFab
+         * Accounts in the same title.
+         */
         PSNInfo?: UserPsnInfo,
-        /** Available Steam information (if the user and PlayFab friend are also connected in Steam). */
+        /** Available Steam information (if the user and connected Steam friend both have PlayFab Accounts in the same title). */
         SteamInfo?: UserSteamInfo,
         /** Tags which have been associated with this friend. */
         Tags?: string[],
@@ -1095,14 +1180,12 @@ declare namespace PlayFabServerModels {
         TitleDisplayName?: string,
         /** PlayFab unique username for this friend. */
         Username?: string,
-        /** Available Xbox information, if the user and PlayFab friend are both connected to Xbox Live. */
+        /** Available Xbox information, (if the user and connected Xbox Live friend both have PlayFab Accounts in the same title). */
         XboxInfo?: UserXboxInfo,
     }
 
-    type GameInstanceState = "Open"
-        | "Closed";
-
     type GenericErrorCodes = "Success"
+
         | "UnkownError"
         | "InvalidParams"
         | "AccountNotFound"
@@ -1206,7 +1289,6 @@ declare namespace PlayFabServerModels {
         | "UnableToConnectToDatabase"
         | "InternalServerError"
         | "InvalidReportDate"
-        | "ReportNotAvailable"
         | "DatabaseThroughputExceeded"
         | "InvalidGameTicket"
         | "ExpiredGameTicket"
@@ -1631,6 +1713,79 @@ declare namespace PlayFabServerModels {
         | "PhotonApplicationIdAlreadyInUse"
         | "CloudScriptUnableToDeleteProductionRevision"
         | "CustomIdNotFound"
+        | "AutomationInvalidInput"
+        | "AutomationInvalidRuleName"
+        | "AutomationRuleAlreadyExists"
+        | "AutomationRuleLimitExceeded"
+        | "InvalidGooglePlayGamesServerAuthCode"
+        | "PlayStreamConnectionFailed"
+        | "InvalidEventContents"
+        | "InsightsV1Deprecated"
+        | "AnalysisSubscriptionNotFound"
+        | "AnalysisSubscriptionFailed"
+        | "AnalysisSubscriptionFoundAlready"
+        | "AnalysisSubscriptionManagementInvalidInput"
+        | "InvalidGameCenterId"
+        | "InvalidNintendoSwitchAccountId"
+        | "EntityAPIKeysNotSupported"
+        | "IpAddressBanned"
+        | "EntityLineageBanned"
+        | "NamespaceMismatch"
+        | "InvalidServiceConfiguration"
+        | "InvalidNamespaceMismatch"
+        | "LeaderboardColumnLengthMismatch"
+        | "InvalidStatisticScore"
+        | "LeaderboardColumnsNotSpecified"
+        | "LeaderboardMaxSizeTooLarge"
+        | "InvalidAttributeStatisticsSpecified"
+        | "LeaderboardNotFound"
+        | "TokenSigningKeyNotFound"
+        | "LeaderboardNameConflict"
+        | "LinkedStatisticColumnMismatch"
+        | "NoLinkedStatisticToLeaderboard"
+        | "StatDefinitionAlreadyLinkedToLeaderboard"
+        | "LinkingStatsNotAllowedForEntityType"
+        | "LeaderboardCountLimitExceeded"
+        | "LeaderboardSizeLimitExceeded"
+        | "LeaderboardDefinitionModificationNotAllowedWhileLinked"
+        | "StatisticDefinitionModificationNotAllowedWhileLinked"
+        | "LeaderboardUpdateNotAllowedWhileLinked"
+        | "CloudScriptAzureFunctionsEventHubRequestError"
+        | "ExternalEntityNotAllowedForTier"
+        | "InvalidBaseTimeForInterval"
+        | "EntityTypeMismatchWithStatDefinition"
+        | "SpecifiedVersionLeaderboardNotFound"
+        | "LeaderboardColumnLengthMismatchWithStatDefinition"
+        | "DuplicateColumnNameFound"
+        | "LinkedStatisticColumnNotFound"
+        | "LinkedStatisticColumnRequired"
+        | "MultipleLinkedStatisticsNotAllowed"
+        | "DuplicateLinkedStatisticColumnNameFound"
+        | "AggregationTypeNotAllowedForMultiColumnStatistic"
+        | "MaxQueryableVersionsValueNotAllowedForTier"
+        | "StatisticDefinitionHasNullOrEmptyVersionConfiguration"
+        | "StatisticColumnLengthMismatch"
+        | "InvalidExternalEntityId"
+        | "UpdatingStatisticsUsingTransactionIdNotAvailableForFreeTier"
+        | "TransactionAlreadyApplied"
+        | "ReportDataNotRetrievedSuccessfully"
+        | "ResetIntervalCannotBeModified"
+        | "VersionIncrementRateExceeded"
+        | "InvalidSteamUsername"
+        | "InvalidVersionResetForLinkedLeaderboard"
+        | "BattleNetNotEnabledForTitle"
+        | "ReportNotProcessed"
+        | "DataNotAvailable"
+        | "InvalidReportName"
+        | "ResourceNotModified"
+        | "StudioCreationLimitExceeded"
+        | "StudioDeletionInitiated"
+        | "ProductDisabledForTitle"
+        | "PreconditionFailed"
+        | "CannotEnableAnonymousPlayerCreation"
+        | "ParentCustomerAccountNotFound"
+        | "AccountLinkedToABannedPlayer"
+        | "AzureSubscriptionNotEligibleForLinking"
         | "MatchmakingEntityInvalid"
         | "MatchmakingPlayerAttributesInvalid"
         | "MatchmakingQueueNotFound"
@@ -1674,6 +1829,8 @@ declare namespace PlayFabServerModels {
         | "CatalogItemTypeInvalid"
         | "CatalogBadRequest"
         | "CatalogTooManyRequests"
+        | "InvalidCatalogItemConfiguration"
+        | "LegacyEconomyDisabled"
         | "ExportInvalidStatusUpdate"
         | "ExportInvalidPrefix"
         | "ExportBlobContainerDoesNotExist"
@@ -1698,6 +1855,7 @@ declare namespace PlayFabServerModels {
         | "ExportCannotParseQuery"
         | "ExportControlCommandsNotAllowed"
         | "ExportQueryMissingTableReference"
+        | "ExportInsightsV1Deprecated"
         | "ExplorerBasicInvalidQueryName"
         | "ExplorerBasicInvalidQueryDescription"
         | "ExplorerBasicInvalidQueryConditions"
@@ -1718,6 +1876,8 @@ declare namespace PlayFabServerModels {
         | "PartyVersionNotFound"
         | "MultiplayerServerBuildReferencedByMatchmakingQueue"
         | "MultiplayerServerBuildReferencedByBuildAlias"
+        | "MultiplayerServerBuildAliasReferencedByMatchmakingQueue"
+        | "PartySerializationError"
         | "ExperimentationExperimentStopped"
         | "ExperimentationExperimentRunning"
         | "ExperimentationExperimentNotFound"
@@ -1741,6 +1901,8 @@ declare namespace PlayFabServerModels {
         | "ExperimentationExclusionGroupCannotDelete"
         | "ExperimentationExclusionGroupInvalidTrafficAllocation"
         | "ExperimentationExclusionGroupInvalidName"
+        | "ExperimentationLegacyExperimentInvalidOperation"
+        | "ExperimentationExperimentStopFailed"
         | "MaxActionDepthExceeded"
         | "TitleNotOnUpdatedPricingPlan"
         | "SegmentManagementTitleNotInFlight"
@@ -1757,8 +1919,11 @@ declare namespace PlayFabServerModels {
         | "AsyncExportNotInFlight"
         | "AsyncExportNotFound"
         | "AsyncExportRateLimitExceeded"
+        | "AnalyticsSegmentCountOverLimit"
+        | "GetPlayersInSegmentDeprecated"
         | "SnapshotNotFound"
         | "InventoryApiNotImplemented"
+        | "InventoryCollectionDeletionDisallowed"
         | "LobbyDoesNotExist"
         | "LobbyRateLimitExceeded"
         | "LobbyPlayerAlreadyJoined"
@@ -1771,10 +1936,23 @@ declare namespace PlayFabServerModels {
         | "LobbyNewOwnerMustBeConnected"
         | "LobbyCurrentOwnerStillConnected"
         | "LobbyMemberIsNotOwner"
+        | "LobbyServerMismatch"
+        | "LobbyServerNotFound"
+        | "LobbyDifferentServerAlreadyJoined"
+        | "LobbyServerAlreadyJoined"
+        | "LobbyIsNotClientOwned"
+        | "LobbyDoesNotUseConnections"
         | "EventSamplingInvalidRatio"
         | "EventSamplingInvalidEventNamespace"
         | "EventSamplingInvalidEventName"
         | "EventSamplingRatioNotFound"
+        | "TelemetryKeyNotFound"
+        | "TelemetryKeyInvalidName"
+        | "TelemetryKeyAlreadyExists"
+        | "TelemetryKeyInvalid"
+        | "TelemetryKeyCountOverLimit"
+        | "TelemetryKeyDeactivated"
+        | "TelemetryKeyLongInsightsRetentionNotAllowed"
         | "EventSinkConnectionInvalid"
         | "EventSinkConnectionUnauthorized"
         | "EventSinkRegionInvalid"
@@ -1784,9 +1962,172 @@ declare namespace PlayFabServerModels {
         | "EventSinkNameInvalid"
         | "EventSinkSasTokenPermissionInvalid"
         | "EventSinkSecretInvalid"
+        | "EventSinkTenantNotFound"
+        | "EventSinkAadNotFound"
+        | "EventSinkDatabaseNotFound"
+        | "EventSinkTitleUnauthorized"
+        | "EventSinkInsufficientRoleAssignment"
+        | "EventSinkContainerNotFound"
+        | "EventSinkTenantIdInvalid"
+        | "EventSinkResourceMisconfigured"
+        | "EventSinkAccessDenied"
+        | "EventSinkWriteConflict"
+        | "EventSinkResourceNotFound"
+        | "EventSinkResourceFeatureNotSupported"
+        | "EventSinkBucketNameInvalid"
+        | "EventSinkResourceUnavailable"
         | "OperationCanceled"
         | "InvalidDisplayNameRandomSuffixLength"
-        | "AllowNonUniquePlayerDisplayNamesDisableNotAllowed";
+        | "AllowNonUniquePlayerDisplayNamesDisableNotAllowed"
+        | "PartitionedEventInvalid"
+        | "PartitionedEventCountOverLimit"
+        | "ManageEventNamespaceInvalid"
+        | "ManageEventNameInvalid"
+        | "ManagedEventNotFound"
+        | "ManageEventsInvalidRatio"
+        | "ManagedEventInvalid"
+        | "PlayerCustomPropertiesPropertyNameTooLong"
+        | "PlayerCustomPropertiesPropertyNameIsInvalid"
+        | "PlayerCustomPropertiesStringPropertyValueTooLong"
+        | "PlayerCustomPropertiesValueIsInvalidType"
+        | "PlayerCustomPropertiesVersionMismatch"
+        | "PlayerCustomPropertiesPropertyCountTooHigh"
+        | "PlayerCustomPropertiesDuplicatePropertyName"
+        | "PlayerCustomPropertiesPropertyDoesNotExist"
+        | "AddonAlreadyExists"
+        | "AddonDoesntExist"
+        | "CopilotDisabled"
+        | "CopilotInvalidRequest"
+        | "TrueSkillUnauthorized"
+        | "TrueSkillInvalidTitleId"
+        | "TrueSkillInvalidScenarioId"
+        | "TrueSkillInvalidModelId"
+        | "TrueSkillInvalidModelName"
+        | "TrueSkillInvalidPlayerIds"
+        | "TrueSkillInvalidEntityKey"
+        | "TrueSkillInvalidConditionKey"
+        | "TrueSkillInvalidConditionValue"
+        | "TrueSkillInvalidConditionAffinityWeight"
+        | "TrueSkillInvalidEventName"
+        | "TrueSkillMatchResultCreated"
+        | "TrueSkillMatchResultAlreadySubmitted"
+        | "TrueSkillBadPlayerIdInMatchResult"
+        | "TrueSkillInvalidBotIdInMatchResult"
+        | "TrueSkillDuplicatePlayerInMatchResult"
+        | "TrueSkillNoPlayerInMatchResultTeam"
+        | "TrueSkillPlayersInMatchResultExceedingLimit"
+        | "TrueSkillInvalidPreMatchPartyInMatchResult"
+        | "TrueSkillInvalidTimestampInMatchResult"
+        | "TrueSkillStartTimeMissingInMatchResult"
+        | "TrueSkillEndTimeMissingInMatchResult"
+        | "TrueSkillInvalidPlayerSecondsPlayedInMatchResult"
+        | "TrueSkillNoTeamInMatchResult"
+        | "TrueSkillNotEnoughTeamsInMatchResult"
+        | "TrueSkillInvalidRanksInMatchResult"
+        | "TrueSkillNoWinnerInMatchResult"
+        | "TrueSkillMissingRequiredCondition"
+        | "TrueSkillMissingRequiredEvent"
+        | "TrueSkillUnknownEventName"
+        | "TrueSkillInvalidEventCount"
+        | "TrueSkillUnknownConditionKey"
+        | "TrueSkillUnknownConditionValue"
+        | "TrueSkillScenarioConfigDoesNotExist"
+        | "TrueSkillUnknownModelId"
+        | "TrueSkillNoModelInScenario"
+        | "TrueSkillNotSupportedForTitle"
+        | "TrueSkillModelIsNotActive"
+        | "TrueSkillUnauthorizedToQueryOtherPlayerSkills"
+        | "TrueSkillInvalidMaxIterations"
+        | "TrueSkillEndTimeBeforeStartTime"
+        | "TrueSkillInvalidJobId"
+        | "TrueSkillInvalidMetadataId"
+        | "TrueSkillMissingBuildVerison"
+        | "TrueSkillJobAlreadyExists"
+        | "TrueSkillJobNotFound"
+        | "TrueSkillOperationCanceled"
+        | "TrueSkillActiveModelLimitExceeded"
+        | "TrueSkillTotalModelLimitExceeded"
+        | "TrueSkillUnknownInitialModelId"
+        | "TrueSkillUnauthorizedForJob"
+        | "TrueSkillInvalidScenarioName"
+        | "TrueSkillConditionStateIsRequired"
+        | "TrueSkillEventStateIsRequired"
+        | "TrueSkillDuplicateEvent"
+        | "TrueSkillDuplicateCondition"
+        | "TrueSkillInvalidAnomalyThreshold"
+        | "TrueSkillConditionKeyLimitExceeded"
+        | "TrueSkillConditionValuePerKeyLimitExceeded"
+        | "TrueSkillInvalidTimestamp"
+        | "TrueSkillEventLimitExceeded"
+        | "TrueSkillInvalidPlayers"
+        | "TrueSkillTrueSkillPlayerNull"
+        | "TrueSkillInvalidPlayerId"
+        | "TrueSkillInvalidSquadSize"
+        | "TrueSkillConditionSetNotInModel"
+        | "TrueSkillModelStateInvalidForOperation"
+        | "TrueSkillScenarioContainsActiveModel"
+        | "TrueSkillInvalidConditionRank"
+        | "TrueSkillTotalScenarioLimitExceeded"
+        | "TrueSkillInvalidConditionsList"
+        | "GameSaveManifestNotFound"
+        | "GameSaveManifestVersionAlreadyExists"
+        | "GameSaveConflictUpdatingManifest"
+        | "GameSaveManifestUpdatesNotAllowed"
+        | "GameSaveFileAlreadyExists"
+        | "GameSaveManifestVersionNotFinalized"
+        | "GameSaveUnknownFileInManifest"
+        | "GameSaveFileExceededReportedSize"
+        | "GameSaveFileNotUploaded"
+        | "GameSaveBadRequest"
+        | "GameSaveOperationNotAllowed"
+        | "GameSaveDataStorageQuotaExceeded"
+        | "GameSaveNewerManifestExists"
+        | "GameSaveBaseVersionNotAvailable"
+        | "GameSaveManifestVersionQuarantined"
+        | "GameSaveManifestUploadProgressUpdateNotAllowed"
+        | "GameSaveNotFinalizedManifestNotEligibleAsKnownGood"
+        | "GameSaveNoUpdatesRequested"
+        | "GameSaveTitleDoesNotExist"
+        | "GameSaveOperationNotAllowedForTitle"
+        | "GameSaveManifestFilesLimitExceeded"
+        | "GameSaveManifestDescriptionUpdateNotAllowed"
+        | "GameSaveTitleConfigNotFound"
+        | "GameSaveTitleAlreadyOnboarded"
+        | "GameSaveServiceNotEnabledForTitle"
+        | "GameSaveServiceOnboardingPending"
+        | "GameSaveManifestNotEligibleAsConflictingVersion"
+        | "GameSaveServiceUnavailable"
+        | "GameSaveConflict"
+        | "GameSaveManifestNotEligibleForRollback"
+        | "GameSaveTitleClientAnonymousAccountCreationNotDisabled"
+        | "StateShareForbidden"
+        | "StateShareTitleNotInFlight"
+        | "StateShareStateNotFound"
+        | "StateShareLinkNotFound"
+        | "StateShareStateRedemptionLimitExceeded"
+        | "StateShareStateRedemptionLimitNotUpdated"
+        | "StateShareCreatedStatesLimitExceeded"
+        | "StateShareIdMissingOrMalformed"
+        | "PlayerCreationDisabled"
+        | "AccountAlreadyExists"
+        | "TagInvalid"
+        | "TagTooLong"
+        | "StatisticColumnAggregationMismatch"
+        | "StatisticResetIntervalMismatch"
+        | "VersionConfigurationCannotBeSpecifiedForLinkedStat"
+        | "VersionConfigurationIsRequired"
+        | "InvalidEntityTypeForAggregation"
+        | "MultiLevelAggregationNotAllowed"
+        | "AggregationTypeNotAllowedForLinkedStat"
+        | "OperationDeniedDueToDefinitionPolicy"
+        | "StatisticUpdateNotAllowedWhileLinked"
+        | "UnsupportedEntityType"
+        | "EntityTypeSpecifiedRequiresAggregationSource"
+        | "PlayFabErrorEventNotSupportedForEntityType"
+        | "MetadataLengthExceeded"
+        | "MaxQueryableVersionsExceeded"
+        | "StoreMetricsRequestInvalidInput"
+        | "StoreMetricsErrorRetrievingMetrics";
 
     interface GenericPlayFabIdPair {
         /** Unique generic service identifier for a user. */
@@ -1883,8 +2224,6 @@ declare namespace PlayFabServerModels {
     }
 
     interface GetCharacterLeaderboardRequest {
-        /** Optional character type on which to filter the leaderboard entries. */
-        CharacterType?: string,
         /** Maximum number of entries to retrieve. */
         MaxResultsCount: number,
         /** First entry in the leaderboard to be retrieved. */
@@ -1940,10 +2279,11 @@ declare namespace PlayFabServerModels {
     interface GetFriendLeaderboardRequest {
         /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
         CustomTags?: { [key: string]: string | null },
-        /** Indicates whether Facebook friends should be included in the response. Default is true. */
-        IncludeFacebookFriends?: boolean,
-        /** Indicates whether Steam service friends should be included in the response. Default is true. */
-        IncludeSteamFriends?: boolean,
+        /**
+         * Indicates which other platforms' friends should be included in the response. In HTTP, it is represented as a
+         * comma-separated list of platforms.
+         */
+        ExternalPlatformFriends?: ExternalFriendSources,
         /** Maximum number of entries to retrieve. */
         MaxResultsCount: number,
         /** The player whose friend leaderboard to get */
@@ -1967,10 +2307,11 @@ declare namespace PlayFabServerModels {
     interface GetFriendsListRequest {
         /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
         CustomTags?: { [key: string]: string | null },
-        /** Indicates whether Facebook friends should be included in the response. Default is true. */
-        IncludeFacebookFriends?: boolean,
-        /** Indicates whether Steam service friends should be included in the response. Default is true. */
-        IncludeSteamFriends?: boolean,
+        /**
+         * Indicates which other platforms' friends should be included in the response. In HTTP, it is represented as a
+         * comma-separated list of platforms.
+         */
+        ExternalPlatformFriends?: ExternalFriendSources,
         /** PlayFab identifier of the player whose friend list to get. */
         PlayFabId: string,
         /**
@@ -1997,8 +2338,6 @@ declare namespace PlayFabServerModels {
     interface GetLeaderboardAroundCharacterRequest {
         /** Unique PlayFab assigned ID for a specific character owned by a user */
         CharacterId: string,
-        /** Optional character type on which to filter the leaderboard entries. */
-        CharacterType?: string,
         /** Maximum number of entries to retrieve. */
         MaxResultsCount: number,
         /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
@@ -2178,6 +2517,25 @@ declare namespace PlayFabServerModels {
         UserVirtualCurrencyRechargeTimes?: { [key: string]: VirtualCurrencyRechargeTime },
     }
 
+    interface GetPlayerCustomPropertyRequest {
+        /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
+        PlayFabId: string,
+        /** Specific property name to search for in the player's properties. */
+        PropertyName: string,
+    }
+
+    interface GetPlayerCustomPropertyResult {
+        /** PlayFab unique identifier of the user whose properties are being returned. */
+        PlayFabId?: string,
+        /**
+         * Indicates the current version of a player's properties that have been set. This is incremented after updates and
+         * deletes. This version can be provided in update and delete calls for concurrency control.
+         */
+        PropertiesVersion: number,
+        /** Player specific property and its corresponding value. */
+        Property?: CustomPropertyDetails,
+    }
+
     /**
      * This API allows for access to details regarding a user in the PlayFab service, usually for purposes of customer support.
      * Note that data returned may be Personally Identifying Information (PII), such as email address, and so care should be
@@ -2224,11 +2582,20 @@ declare namespace PlayFabServerModels {
         ContinuationToken?: string,
         /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
         CustomTags?: { [key: string]: string | null },
-        /** Maximum number of profiles to load. Default is 1,000. Maximum is 10,000. */
+        /**
+         * If set to true, the profiles are loaded asynchronously and the response will include a continuation token and
+         * approximate profile count until the first batch of profiles is loaded. Use this parameter to help avoid network
+         * timeouts.
+         */
+        GetProfilesAsync?: boolean,
+        /**
+         * Maximum is 10,000. The value 0 will prevent loading any profiles and return only the count of profiles matching this
+         * segment.
+         */
         MaxBatchSize?: number,
         /**
          * Number of seconds to keep the continuation token active. After token expiration it is not possible to continue paging
-         * results. Default is 300 (5 minutes). Maximum is 1,800 (30 minutes).
+         * results. Default is 300 (5 minutes). Maximum is 5,400 (90 minutes).
          */
         SecondsToLive?: number,
         /** Unique identifier for this segment. */
@@ -2306,8 +2673,25 @@ declare namespace PlayFabServerModels {
         Tags: string[],
     }
 
+    interface GetPlayFabIDsFromBattleNetAccountIdsRequest {
+        /**
+         * Array of unique Battle.net account identifiers for which the title needs to get PlayFab identifiers. The array cannot
+         * exceed 10 in length.
+         */
+        BattleNetAccountIds: string[],
+    }
+
+    /** For Battle.net account identifiers which have not been linked to PlayFab accounts, null will be returned. */
+    interface GetPlayFabIDsFromBattleNetAccountIdsResult {
+        /** Mapping of Battle.net account identifiers to PlayFab identifiers. */
+        Data?: BattleNetAccountPlayFabIdPair[],
+    }
+
     interface GetPlayFabIDsFromFacebookIDsRequest {
-        /** Array of unique Facebook identifiers for which the title needs to get PlayFab identifiers. */
+        /**
+         * Array of unique Facebook identifiers for which the title needs to get PlayFab identifiers. The array cannot exceed 25 in
+         * length.
+         */
         FacebookIDs: string[],
     }
 
@@ -2318,7 +2702,10 @@ declare namespace PlayFabServerModels {
     }
 
     interface GetPlayFabIDsFromFacebookInstantGamesIdsRequest {
-        /** Array of unique Facebook Instant Games identifiers for which the title needs to get PlayFab identifiers. */
+        /**
+         * Array of unique Facebook Instant Games identifiers for which the title needs to get PlayFab identifiers. The array
+         * cannot exceed 25 in length.
+         */
         FacebookInstantGamesIds: string[],
     }
 
@@ -2343,7 +2730,10 @@ declare namespace PlayFabServerModels {
     }
 
     interface GetPlayFabIDsFromNintendoServiceAccountIdsRequest {
-        /** Array of unique Nintendo Switch Account identifiers for which the title needs to get PlayFab identifiers. */
+        /**
+         * Array of unique Nintendo Switch Account identifiers for which the title needs to get PlayFab identifiers. The array
+         * cannot exceed 25 in length.
+         */
         NintendoAccountIds: string[],
     }
 
@@ -2354,7 +2744,10 @@ declare namespace PlayFabServerModels {
     }
 
     interface GetPlayFabIDsFromNintendoSwitchDeviceIdsRequest {
-        /** Array of unique Nintendo Switch Device identifiers for which the title needs to get PlayFab identifiers. */
+        /**
+         * Array of unique Nintendo Switch Device identifiers for which the title needs to get PlayFab identifiers. The array
+         * cannot exceed 25 in length.
+         */
         NintendoSwitchDeviceIds: string[],
     }
 
@@ -2364,21 +2757,57 @@ declare namespace PlayFabServerModels {
         Data?: NintendoSwitchPlayFabIdPair[],
     }
 
+    interface GetPlayFabIDsFromOpenIdsRequest {
+        /**
+         * Array of unique OpenId Connect identifiers for which the title needs to get PlayFab identifiers. The array cannot exceed
+         * 10 in length.
+         */
+        OpenIdSubjectIdentifiers: OpenIdSubjectIdentifier[],
+    }
+
+    /** For OpenId identifiers which have not been linked to PlayFab accounts, null will be returned. */
+    interface GetPlayFabIDsFromOpenIdsResult {
+        /** Mapping of OpenId Connect identifiers to PlayFab identifiers. */
+        Data?: OpenIdSubjectIdentifierPlayFabIdPair[],
+    }
+
     interface GetPlayFabIDsFromPSNAccountIDsRequest {
-        /** Id of the PSN issuer environment. If null, defaults to production environment. */
+        /** Id of the PlayStation :tm: Network issuer environment. If null, defaults to production environment. */
         IssuerId?: number,
-        /** Array of unique PlayStation Network identifiers for which the title needs to get PlayFab identifiers. */
+        /**
+         * Array of unique PlayStation :tm: Network identifiers for which the title needs to get PlayFab identifiers. The array
+         * cannot exceed 25 in length.
+         */
         PSNAccountIDs: string[],
     }
 
-    /** For PlayStation Network identifiers which have not been linked to PlayFab accounts, null will be returned. */
+    /** For PlayStation :tm: Network identifiers which have not been linked to PlayFab accounts, null will be returned. */
     interface GetPlayFabIDsFromPSNAccountIDsResult {
-        /** Mapping of PlayStation Network identifiers to PlayFab identifiers. */
+        /** Mapping of PlayStation :tm: Network identifiers to PlayFab identifiers. */
         Data?: PSNAccountPlayFabIdPair[],
     }
 
+    interface GetPlayFabIDsFromPSNOnlineIDsRequest {
+        /** Id of the PlayStation :tm: Network issuer environment. If null, defaults to production environment. */
+        IssuerId?: number,
+        /**
+         * Array of unique PlayStation :tm: Network identifiers for which the title needs to get PlayFab identifiers. The array
+         * cannot exceed 25 in length.
+         */
+        PSNOnlineIDs: string[],
+    }
+
+    /** For PlayStation :tm: Network identifiers which have not been linked to PlayFab accounts, null will be returned. */
+    interface GetPlayFabIDsFromPSNOnlineIDsResult {
+        /** Mapping of PlayStation :tm: Network identifiers to PlayFab identifiers. */
+        Data?: PSNOnlinePlayFabIdPair[],
+    }
+
     interface GetPlayFabIDsFromSteamIDsRequest {
-        /** Array of unique Steam identifiers (Steam profile IDs) for which the title needs to get PlayFab identifiers. */
+        /**
+         * Array of unique Steam identifiers (Steam profile IDs) for which the title needs to get PlayFab identifiers. The array
+         * cannot exceed 25 in length.
+         */
         SteamStringIDs?: string[],
     }
 
@@ -2388,16 +2817,47 @@ declare namespace PlayFabServerModels {
         Data?: SteamPlayFabIdPair[],
     }
 
+    interface GetPlayFabIDsFromSteamNamesRequest {
+        /**
+         * Array of unique Steam identifiers for which the title needs to get PlayFab identifiers. The array cannot exceed 25 in
+         * length.
+         */
+        SteamNames: string[],
+    }
+
+    /** For Steam identifiers which have not been linked to PlayFab accounts, null will be returned. */
+    interface GetPlayFabIDsFromSteamNamesResult {
+        /** Mapping of Steam identifiers to PlayFab identifiers. */
+        Data?: SteamNamePlayFabIdPair[],
+    }
+
+    interface GetPlayFabIDsFromTwitchIDsRequest {
+        /**
+         * Array of unique Twitch identifiers (Twitch's _id) for which the title needs to get PlayFab identifiers. The array cannot
+         * exceed 25 in length.
+         */
+        TwitchIds: string[],
+    }
+
+    /** For Twitch identifiers which have not been linked to PlayFab accounts, null will be returned. */
+    interface GetPlayFabIDsFromTwitchIDsResult {
+        /** Mapping of Twitch identifiers to PlayFab identifiers. */
+        Data?: TwitchPlayFabIdPair[],
+    }
+
     interface GetPlayFabIDsFromXboxLiveIDsRequest {
         /** The ID of Xbox Live sandbox. */
         Sandbox?: string,
-        /** Array of unique Xbox Live account identifiers for which the title needs to get PlayFab identifiers. */
+        /**
+         * Array of unique Xbox Live account identifiers for which the title needs to get PlayFab identifiers. The array cannot
+         * exceed 25 in length.
+         */
         XboxLiveAccountIDs: string[],
     }
 
     /** For XboxLive identifiers which have not been linked to PlayFab accounts, null will be returned. */
     interface GetPlayFabIDsFromXboxLiveIDsResult {
-        /** Mapping of PlayStation Network identifiers to PlayFab identifiers. */
+        /** Mapping of Xbox Live identifiers to PlayFab identifiers. */
         Data?: XboxLiveAccountPlayFabIdPair[],
     }
 
@@ -2848,6 +3308,17 @@ declare namespace PlayFabServerModels {
         UsesIncrementedBy?: number,
     }
 
+    interface LinkBattleNetAccountRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** If another user is already linked to a specific Battle.net account, unlink the other user and re-link. */
+        ForceLink?: boolean,
+        /** The JSON Web Token (JWT) returned by Battle.net after login */
+        IdentityToken: string,
+        /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
+        PlayFabId: string,
+    }
+
     interface LinkedPlatformAccountModel {
         /** Linked account email of the user on the platform, if available */
         Email?: string,
@@ -2859,22 +3330,77 @@ declare namespace PlayFabServerModels {
         Username?: string,
     }
 
+    interface LinkNintendoServiceAccountRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** If another user is already linked to a specific Nintendo Switch account, unlink the other user and re-link. */
+        ForceLink?: boolean,
+        /**
+         * The JSON Web token (JWT) returned by Nintendo after login. Used to validate the request and find the user ID (Nintendo
+         * Switch subject) to link with.
+         */
+        IdentityToken: string,
+        /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
+        PlayFabId: string,
+    }
+
+    interface LinkNintendoServiceAccountSubjectRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** If another user is already linked to a specific Nintendo Service Account, unlink the other user and re-link. */
+        ForceLink?: boolean,
+        /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
+        PlayFabId: string,
+        /** The Nintendo Service Account subject or id to link to the PlayFab user. */
+        Subject: string,
+    }
+
+    interface LinkNintendoSwitchDeviceIdRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** If another user is already linked to the Nintendo Switch Device ID, unlink the other user and re-link. */
+        ForceLink?: boolean,
+        /** Nintendo Switch unique identifier for the user's device. */
+        NintendoSwitchDeviceId: string,
+        /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
+        PlayFabId: string,
+    }
+
+    interface LinkNintendoSwitchDeviceIdResult {
+    }
+
     interface LinkPSNAccountRequest {
-        /** Authentication code provided by the PlayStation Network. */
+        /** Authentication code provided by the PlayStation :tm: Network. */
         AuthCode: string,
         /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
         CustomTags?: { [key: string]: string | null },
         /** If another user is already linked to the account, unlink the other user and re-link. */
         ForceLink?: boolean,
-        /** Id of the PSN issuer environment. If null, defaults to production environment. */
+        /** Id of the PlayStation :tm: Network issuer environment. If null, defaults to production environment. */
         IssuerId?: number,
         /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
         PlayFabId: string,
-        /** Redirect URI supplied to PSN when requesting an auth code */
+        /** Redirect URI supplied to PlayStation :tm: Network when requesting an auth code */
         RedirectUri: string,
     }
 
     interface LinkPSNAccountResult {
+    }
+
+    interface LinkPSNIdRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** If another user is already linked to the account, unlink the other user and re-link. */
+        ForceLink?: boolean,
+        /** Id of the PlayStation :tm: Network issuer environment. If null, defaults to production environment. */
+        IssuerId?: number,
+        /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
+        PlayFabId: string,
+        /** Id of the PlayStation :tm: Network user. Also known as the PSN Account Id. */
+        PSNUserId: string,
+    }
+
+    interface LinkPSNIdResponse {
     }
 
     interface LinkServerCustomIdRequest {
@@ -2891,18 +3417,73 @@ declare namespace PlayFabServerModels {
     interface LinkServerCustomIdResult {
     }
 
+    interface LinkSteamIdRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** If another user is already linked to the account, unlink the other user and re-link. */
+        ForceLink?: boolean,
+        /** PlayFab unique identifier of the user to link. */
+        PlayFabId: string,
+        /** Unique Steam identifier for a user. */
+        SteamId: string,
+    }
+
+    interface LinkSteamIdResult {
+    }
+
+    interface LinkTwitchAccountRequest {
+        /** Twitch access token for authentication. */
+        AccessToken: string,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** If another user is already linked to the account, unlink the other user and re-link. */
+        ForceLink?: boolean,
+        /** PlayFab unique identifier of the user to link. */
+        PlayFabId: string,
+    }
+
     interface LinkXboxAccountRequest {
         /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
         CustomTags?: { [key: string]: string | null },
         /** If another user is already linked to the account, unlink the other user and re-link. */
         ForceLink?: boolean,
-        /** Unique PlayFab identifier for a user, or null if no PlayFab account is linked to the Xbox Live identifier. */
+        /** PlayFab unique identifier of the user to link. */
         PlayFabId: string,
         /** Token provided by the Xbox Live SDK/XDK method GetTokenAndSignatureAsync("POST", "https://playfabapi.com/", ""). */
         XboxToken: string,
     }
 
     interface LinkXboxAccountResult {
+    }
+
+    interface LinkXboxIdRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** If another user is already linked to the account, unlink the other user and re-link. */
+        ForceLink?: boolean,
+        /** PlayFab unique identifier of the user to link. */
+        PlayFabId: string,
+        /** The id of Xbox Live sandbox. */
+        Sandbox: string,
+        /** Unique Xbox identifier for a user. */
+        XboxId: string,
+    }
+
+    interface ListPlayerCustomPropertiesRequest {
+        /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
+        PlayFabId: string,
+    }
+
+    interface ListPlayerCustomPropertiesResult {
+        /** PlayFab unique identifier of the user whose properties are being returned. */
+        PlayFabId?: string,
+        /** Player specific properties and their corresponding values for this title. */
+        Properties?: CustomPropertyDetails[],
+        /**
+         * Indicates the current version of a player's properties that have been set. This is incremented after updates and
+         * deletes. This version can be provided in update and delete calls for concurrency control.
+         */
+        PropertiesVersion: number,
     }
 
     /** Returns a list of every character that currently belongs to a user. */
@@ -2938,6 +3519,7 @@ declare namespace PlayFabServerModels {
     }
 
     type LoginIdentityProvider = "Unknown"
+
         | "PlayFab"
         | "Custom"
         | "GameCenter"
@@ -2959,6 +3541,109 @@ declare namespace PlayFabServerModels {
         | "Apple"
         | "NintendoSwitchAccount";
 
+    /**
+     * On Android devices, the recommendation is to use the Settings.Secure.ANDROID_ID as the AndroidDeviceId, as described in
+     * this blog post (http://android-developers.blogspot.com/2011/03/identifying-app-installations.html). More information on
+     * this identifier can be found in the Android documentation
+     * (http://developer.android.com/reference/android/provider/Settings.Secure.html). If this is the first time a user has
+     * signed in with the Android device and CreateAccount is set to true, a new PlayFab account will be created and linked to
+     * the Android device ID. In this case, no email or username will be associated with the PlayFab account. Otherwise, if no
+     * PlayFab account is linked to the Android device, an error indicating this will be returned, so that the title can guide
+     * the user through creation of a PlayFab account. Please note that while multiple devices of this type can be linked to a
+     * single user account, only the one most recently used to login (or most recently linked) will be reflected in the user's
+     * account information. We will be updating to show all linked devices in a future release.
+     */
+    interface LoginWithAndroidDeviceIDRequest {
+        /** Specific model of the user's device. */
+        AndroidDevice?: string,
+        /** Android device identifier for the user's device. */
+        AndroidDeviceId: string,
+        /** Automatically create a PlayFab account if one is not currently linked to this ID. */
+        CreateAccount?: boolean,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** Flags for which pieces of info to return for the user. */
+        InfoRequestParameters?: GetPlayerCombinedInfoRequestParams,
+        /** Specific Operating System version for the user's device. */
+        OS?: string,
+    }
+
+    interface LoginWithBattleNetRequest {
+        /** Automatically create a PlayFab account if one is not currently linked to this ID. */
+        CreateAccount?: boolean,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The JSON Web Token (JWT) returned by Battle.net after login */
+        IdentityToken: string,
+        /** Flags for which pieces of info to return for the user. */
+        InfoRequestParameters?: GetPlayerCombinedInfoRequestParams,
+    }
+
+    /**
+     * It is highly recommended that developers ensure that it is extremely unlikely that a customer could generate an ID which
+     * is already in use by another customer. If this is the first time a user has signed in with the Custom ID and
+     * CreateAccount is set to true, a new PlayFab account will be created and linked to the Custom ID. In this case, no email
+     * or username will be associated with the PlayFab account. Otherwise, if no PlayFab account is linked to the Custom ID, an
+     * error indicating this will be returned, so that the title can guide the user through creation of a PlayFab account.
+     */
+    interface LoginWithCustomIDRequest {
+        /** Automatically create a PlayFab account if one is not currently linked to this ID. */
+        CreateAccount?: boolean,
+        /** Custom unique identifier for the user, generated by the title. */
+        CustomId: string,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** Flags for which pieces of info to return for the user. */
+        InfoRequestParameters?: GetPlayerCombinedInfoRequestParams,
+    }
+
+    /**
+     * On iOS devices, the identifierForVendor
+     * (https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIDevice_Class/index.html#//apple_ref/occ/instp/UIDevice/identifierForVendor)
+     * must be used as the DeviceId, as the UIDevice uniqueIdentifier has been deprecated as of iOS 5, and use of the
+     * advertisingIdentifier for this purpose will result in failure of Apple's certification process. If this is the first
+     * time a user has signed in with the iOS device and CreateAccount is set to true, a new PlayFab account will be created
+     * and linked to the vendor-specific iOS device ID. In this case, no email or username will be associated with the PlayFab
+     * account. Otherwise, if no PlayFab account is linked to the iOS device, an error indicating this will be returned, so
+     * that the title can guide the user through creation of a PlayFab account.
+     */
+    interface LoginWithIOSDeviceIDRequest {
+        /** Automatically create a PlayFab account if one is not currently linked to this ID. */
+        CreateAccount?: boolean,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** Vendor-specific iOS identifier for the user's device. */
+        DeviceId: string,
+        /** Specific model of the user's device. */
+        DeviceModel?: string,
+        /** Flags for which pieces of info to return for the user. */
+        InfoRequestParameters?: GetPlayerCombinedInfoRequestParams,
+        /** Specific Operating System version for the user's device. */
+        OS?: string,
+    }
+
+    /**
+     * If this is the first time a user has signed in with the PlayStation :tm: Network account and CreateAccount is set to
+     * true, a new PlayFab account will be created and linked to the PlayStation :tm: Network account. In this case, no email
+     * or username will be associated with the PlayFab account. Otherwise, if no PlayFab account is linked to the PlayStation
+     * :tm: Network account, an error indicating this will be returned, so that the title can guide the user through creation
+     * of a PlayFab account.
+     */
+    interface LoginWithPSNRequest {
+        /** Auth code provided by the PlayStation :tm: Network OAuth provider. */
+        AuthCode: string,
+        /** Automatically create a PlayFab account if one is not currently linked to this ID. */
+        CreateAccount?: boolean,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** Flags for which pieces of info to return for the user. */
+        InfoRequestParameters?: GetPlayerCombinedInfoRequestParams,
+        /** Id of the PlayStation :tm: Network issuer environment. If null, defaults to production environment. */
+        IssuerId?: number,
+        /** Redirect URI supplied to PlayStation :tm: Network when requesting an auth code */
+        RedirectUri: string,
+    }
+
     interface LoginWithServerCustomIdRequest {
         /** Automatically create a PlayFab account if one is not currently linked to this ID. */
         CreateAccount?: boolean,
@@ -2969,7 +3654,7 @@ declare namespace PlayFabServerModels {
         /** Player secret that is used to verify API request signatures (Enterprise Only). */
         PlayerSecret?: string,
         /** The backend server identifier for this player. */
-        ServerCustomId?: string,
+        ServerCustomId: string,
     }
 
     /**
@@ -2987,8 +3672,32 @@ declare namespace PlayFabServerModels {
         CustomTags?: { [key: string]: string | null },
         /** Flags for which pieces of info to return for the user. */
         InfoRequestParameters?: GetPlayerCombinedInfoRequestParams,
-        /** Unique Steam identifier for a user */
+        /** Unique Steam identifier for a user. */
         SteamId: string,
+    }
+
+    /**
+     * More details regarding Twitch and their authentication system can be found at
+     * https://github.com/justintv/Twitch-API/blob/master/authentication.md. Developers must provide the Twitch access token
+     * that is generated using one of the Twitch authentication flows. PlayFab will use the title's unique Twitch Client ID to
+     * authenticate the token and log in to the PlayFab system. If CreateAccount is set to true and there is not already a user
+     * matched to the Twitch username that generated the token, then PlayFab will create a new account for this user and link
+     * the ID. In this case, no email or username will be associated with the PlayFab account. If there is already a different
+     * PlayFab user linked with this account, then an error will be returned.
+     */
+    interface LoginWithTwitchRequest {
+        /** Twitch access token for authentication. */
+        AccessToken: string,
+        /** If true, create a new PlayFab account if one does not exist. */
+        CreateAccount?: boolean,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** Parameters for requesting additional player info. */
+        InfoRequestParameters?: GetPlayerCombinedInfoRequestParams,
+        /** Player secret for additional authentication. */
+        PlayerSecret?: string,
+        /** PlayFab unique identifier of the user. */
+        PlayFabId: string,
     }
 
     /**
@@ -3006,7 +3715,7 @@ declare namespace PlayFabServerModels {
         InfoRequestParameters?: GetPlayerCombinedInfoRequestParams,
         /** The id of Xbox Live sandbox. */
         Sandbox: string,
-        /** Unique Xbox identifier for a user */
+        /** Unique Xbox identifier for a user. */
         XboxId: string,
     }
 
@@ -3162,24 +3871,19 @@ declare namespace PlayFabServerModels {
         PlayFabId?: string,
     }
 
-    interface NotifyMatchmakerPlayerLeftRequest {
-        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
-        CustomTags?: { [key: string]: string | null },
-        /** Unique identifier of the Game Instance the user is leaving. */
-        LobbyId: string,
-        /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
-        PlayFabId: string,
+    interface OpenIdSubjectIdentifier {
+        /** The issuer URL for the OpenId Connect provider, or the override URL if an override exists. */
+        Issuer: string,
+        /** The unique subject identifier within the context of the issuer. */
+        Subject: string,
     }
 
-    interface NotifyMatchmakerPlayerLeftResult {
-        /** State of user leaving the Game Server Instance. */
-        PlayerState?: PlayerConnectionState,
+    interface OpenIdSubjectIdentifierPlayFabIdPair {
+        /** Unique OpenId Connect identifier for a user. */
+        OpenIdSubjectIdentifier?: OpenIdSubjectIdentifier,
+        /** Unique PlayFab identifier for a user, or null if no PlayFab account is linked to the OpenId Connect identifier. */
+        PlayFabId?: string,
     }
-
-    type PlayerConnectionState = "Unassigned"
-        | "Connecting"
-        | "Participating"
-        | "Participated";
 
     interface PlayerLeaderboardEntry {
         /** Title-specific display name of the user for this leaderboard entry. */
@@ -3225,10 +3929,14 @@ declare namespace PlayFabServerModels {
         AvatarUrl?: string,
         /** Banned until UTC Date. If permanent ban this is set for 20 years after the original ban date. */
         BannedUntil?: string,
+        /** The prediction of the player to churn within the next seven days. */
+        ChurnPrediction?: ChurnRiskLevel,
         /** Array of contact email addresses associated with the player */
         ContactEmailAddresses?: ContactEmailInfo[],
         /** Player record created */
         Created?: string,
+        /** Dictionary of player's custom properties. */
+        CustomProperties?: { [key: string]: any },
         /** Player Display Name */
         DisplayName?: string,
         /** Last login */
@@ -3377,10 +4085,23 @@ declare namespace PlayFabServerModels {
     }
 
     interface PSNAccountPlayFabIdPair {
-        /** Unique PlayFab identifier for a user, or null if no PlayFab account is linked to the PlayStation Network identifier. */
+        /**
+         * Unique PlayFab identifier for a user, or null if no PlayFab account is linked to the PlayStation :tm: Network
+         * identifier.
+         */
         PlayFabId?: string,
-        /** Unique PlayStation Network identifier for a user. */
+        /** Unique PlayStation :tm: Network identifier for a user. */
         PSNAccountId?: string,
+    }
+
+    interface PSNOnlinePlayFabIdPair {
+        /**
+         * Unique PlayFab identifier for a user, or null if no PlayFab account is linked to the PlayStation :tm: Network
+         * identifier.
+         */
+        PlayFabId?: string,
+        /** Unique PlayStation :tm: Network identifier for a user. */
+        PSNOnlineId?: string,
     }
 
     interface PushNotificationPackage {
@@ -3399,6 +4120,7 @@ declare namespace PlayFabServerModels {
     }
 
     type PushNotificationPlatform = "ApplePushNotificationService"
+
         | "GoogleCloudMessaging";
 
     interface PushNotificationRegistration {
@@ -3445,86 +4167,6 @@ declare namespace PlayFabServerModels {
     interface RedeemCouponResult {
         /** Items granted to the player as a result of redeeming the coupon. */
         GrantedItems?: ItemInstance[],
-    }
-
-    /**
-     * This function is used by a Game Server Instance to validate with the PlayFab service that a user has been registered as
-     * connected to the server. The Ticket is provided to the client either as a result of a call to StartGame or Matchmake,
-     * each of which return a Ticket specific to the Game Server Instance. This function will fail in any case where the Ticket
-     * presented is not valid for the specific Game Server Instance making the call. Note that data returned may be Personally
-     * Identifying Information (PII), such as email address, and so care should be taken in how this data is stored and
-     * managed. Since this call will always return the relevant information for users who have accessed the title, the
-     * recommendation is to not store this data locally.
-     */
-    interface RedeemMatchmakerTicketRequest {
-        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
-        CustomTags?: { [key: string]: string | null },
-        /** Unique identifier of the Game Server Instance that is asking for validation of the authorization ticket. */
-        LobbyId: string,
-        /** Server authorization ticket passed back from a call to Matchmake or StartGame. */
-        Ticket: string,
-    }
-
-    interface RedeemMatchmakerTicketResult {
-        /** Error value if the ticket was not validated. */
-        Error?: string,
-        /** Boolean indicating whether the ticket was validated by the PlayFab service. */
-        TicketIsValid: boolean,
-        /** User account information for the user validated. */
-        UserInfo?: UserAccountInfo,
-    }
-
-    interface RefreshGameServerInstanceHeartbeatRequest {
-        /** Unique identifier of the Game Server Instance for which the heartbeat is updated. */
-        LobbyId: string,
-    }
-
-    interface RefreshGameServerInstanceHeartbeatResult {
-    }
-
-    type Region = "USCentral"
-        | "USEast"
-        | "EUWest"
-        | "Singapore"
-        | "Japan"
-        | "Brazil"
-        | "Australia";
-
-    interface RegisterGameRequest {
-        /** Unique identifier of the build running on the Game Server Instance. */
-        Build: string,
-        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
-        CustomTags?: { [key: string]: string | null },
-        /**
-         * Game Mode the Game Server instance is running. Note that this must be defined in the Game Modes tab in the PlayFab Game
-         * Manager, along with the Build ID (the same Game Mode can be defined for multiple Build IDs).
-         */
-        GameMode: string,
-        /** Previous lobby id if re-registering an existing game. */
-        LobbyId?: string,
-        /**
-         * Region in which the Game Server Instance is running. For matchmaking using non-AWS region names, set this to any AWS
-         * region and use Tags (below) to specify your custom region.
-         */
-        Region: Region,
-        /** IPV4 address of the game server instance. */
-        ServerIPV4Address?: string,
-        /** IPV6 address (if any) of the game server instance. */
-        ServerIPV6Address?: string,
-        /** Port number for communication with the Game Server Instance. */
-        ServerPort: string,
-        /** Public DNS name (if any) of the server */
-        ServerPublicDNSName?: string,
-        /** Tags for the Game Server Instance */
-        Tags?: { [key: string]: string | null },
-    }
-
-    interface RegisterGameResponse {
-        /**
-         * Unique identifier generated for the Game Server Instance that is registered. If LobbyId is specified in request and the
-         * game still exists in PlayFab, the LobbyId in request is returned. Otherwise a new lobby id will be returned.
-         */
-        LobbyId?: string,
     }
 
     interface RemoveFriendRequest {
@@ -3597,6 +4239,7 @@ declare namespace PlayFabServerModels {
     }
 
     type ResultTableNodeType = "ItemId"
+
         | "TableId";
 
     /**
@@ -3792,7 +4435,7 @@ declare namespace PlayFabServerModels {
         InfoResultPayload?: GetPlayerCombinedInfoResultPayload,
         /** The time of this user's previous login. If there was no previous login, then it's DateTime.MinValue */
         LastLoginTime?: string,
-        /** True if the account was newly created on this login. */
+        /** True if the master_player_account was newly created on this login. */
         NewlyCreated: boolean,
         /** Player's unique PlayFabId. */
         PlayFabId?: string,
@@ -3816,39 +4459,6 @@ declare namespace PlayFabServerModels {
         PlayFabId: string,
         /** Array of tags to set on the friend account. */
         Tags: string[],
-    }
-
-    interface SetGameServerInstanceDataRequest {
-        /** Custom data to set for the specified game server instance. */
-        GameServerData: string,
-        /** Unique identifier of the Game Instance to be updated, in decimal format. */
-        LobbyId: string,
-    }
-
-    interface SetGameServerInstanceDataResult {
-    }
-
-    interface SetGameServerInstanceStateRequest {
-        /** Unique identifier of the Game Instance to be updated, in decimal format. */
-        LobbyId: string,
-        /** State to set for the specified game server instance. */
-        State: GameInstanceState,
-    }
-
-    interface SetGameServerInstanceStateResult {
-    }
-
-    interface SetGameServerInstanceTagsRequest {
-        /** Unique identifier of the Game Server Instance to be updated. */
-        LobbyId: string,
-        /**
-         * Tags to set for the specified Game Server Instance. Note that this is the complete list of tags to be associated with
-         * the Game Server Instance.
-         */
-        Tags: { [key: string]: string | null },
-    }
-
-    interface SetGameServerInstanceTagsResult {
     }
 
     /**
@@ -3897,18 +4507,11 @@ declare namespace PlayFabServerModels {
      * Value. If it already exists, the Value for that key will be overwritten with the new Value.
      */
     interface SetTitleDataRequest {
-        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
-        CustomTags?: { [key: string]: string | null },
         /**
          * key we want to set a value on (note, this is additive - will only replace an existing key's value if they are the same
          * name.) Keys are trimmed of whitespace. Keys may not begin with the '!' character.
          */
         Key: string,
-        /**
-         * Unique identifier for the title, found in the Settings &gt; Game Properties section of the PlayFab developer site when a
-         * title has been selected.
-         */
-        TitleId?: string,
         /** new value to set. Set to null to remove a value */
         Value?: string,
     }
@@ -3928,6 +4531,7 @@ declare namespace PlayFabServerModels {
     }
 
     type SourceType = "Admin"
+
         | "BackEnd"
         | "GameClient"
         | "GameServer"
@@ -3970,6 +4574,13 @@ declare namespace PlayFabServerModels {
         Value: number,
         /** for updates to an existing statistic value for a player, the version of the statistic when it was loaded */
         Version: number,
+    }
+
+    interface SteamNamePlayFabIdPair {
+        /** Unique PlayFab identifier for a user, or null if no PlayFab account is linked to the Steam identifier. */
+        PlayFabId?: string,
+        /** Unique Steam identifier for a user, also known as Steam persona name. */
+        SteamName?: string,
     }
 
     interface SteamPlayFabIdPair {
@@ -4024,6 +4635,7 @@ declare namespace PlayFabServerModels {
     }
 
     type SubscriptionProviderStatus = "NoError"
+
         | "Cancelled"
         | "UnknownError"
         | "BillingError"
@@ -4062,6 +4674,7 @@ declare namespace PlayFabServerModels {
     }
 
     type TitleActivationStatus = "None"
+
         | "ActivatedTitleKey"
         | "PendingSteam"
         | "ActivatedSteam"
@@ -4083,6 +4696,61 @@ declare namespace PlayFabServerModels {
         Variables?: Variable[],
         /** List of the experiment variants. */
         Variants?: string[],
+    }
+
+    interface TwitchPlayFabIdPair {
+        /** Unique PlayFab identifier for a user, or null if no PlayFab account is linked to the Twitch identifier. */
+        PlayFabId?: string,
+        /** Unique Twitch identifier for a user. */
+        TwitchId?: string,
+    }
+
+    interface UnlinkBattleNetAccountRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
+        PlayFabId: string,
+    }
+
+    interface UnlinkFacebookAccountRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** PlayFab unique identifier of the user to unlink. */
+        PlayFabId: string,
+    }
+
+    interface UnlinkFacebookAccountResult {
+    }
+
+    interface UnlinkFacebookInstantGamesIdRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** Facebook Instant Games identifier for the user. If not specified, the most recently linked identifier will be used. */
+        FacebookInstantGamesId?: string,
+        /** PlayFab unique identifier of the user to unlink. */
+        PlayFabId: string,
+    }
+
+    interface UnlinkFacebookInstantGamesIdResult {
+    }
+
+    interface UnlinkNintendoServiceAccountRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
+        PlayFabId: string,
+    }
+
+    interface UnlinkNintendoSwitchDeviceIdRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** Nintendo Switch Device identifier for the user. If not specified, the most recently signed in device ID will be used. */
+        NintendoSwitchDeviceId?: string,
+        /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
+        PlayFabId: string,
+    }
+
+    interface UnlinkNintendoSwitchDeviceIdResult {
     }
 
     interface UnlinkPSNAccountRequest {
@@ -4107,10 +4775,32 @@ declare namespace PlayFabServerModels {
     interface UnlinkServerCustomIdResult {
     }
 
+    interface UnlinkSteamIdRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** Unique PlayFab identifier for a user, or null if no PlayFab account is linked to the Steam account. */
+        PlayFabId: string,
+    }
+
+    interface UnlinkSteamIdResult {
+    }
+
+    interface UnlinkTwitchAccountRequest {
+        /**
+         * Valid token issued by Twitch. Used to specify which twitch account to unlink from the profile. By default it uses the
+         * one that is present on the profile.
+         */
+        AccessToken?: string,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** PlayFab unique identifier of the user to unlink. */
+        PlayFabId: string,
+    }
+
     interface UnlinkXboxAccountRequest {
         /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
         CustomTags?: { [key: string]: string | null },
-        /** Unique PlayFab identifier for a user, or null if no PlayFab account is linked to the Xbox Live identifier. */
+        /** PlayFab unique identifier of the user to unlink. */
         PlayFabId: string,
     }
 
@@ -4185,12 +4875,12 @@ declare namespace PlayFabServerModels {
         Expires?: string,
         /** The updated IP address for the ban. Null for no change. */
         IPAddress?: string,
-        /** The updated MAC address for the ban. Null for no change. */
-        MACAddress?: string,
         /** Whether to make this ban permanent. Set to true to make this ban permanent. This will not modify Active state. */
         Permanent?: boolean,
         /** The updated reason for the ban to be updated. Maximum 140 characters. Null for no change. */
         Reason?: string,
+        /** The updated family type of the user that should be included in the ban. Null for no change. */
+        UserFamilyType?: UserFamilyType,
     }
 
     /**
@@ -4261,6 +4951,35 @@ declare namespace PlayFabServerModels {
     }
 
     /**
+     * Performs an additive update of the custom properties for the specified player. In updating the player's custom
+     * properties, properties which already exist will have their values overwritten. No other properties will be changed apart
+     * from those specified in the call.
+     */
+    interface UpdatePlayerCustomPropertiesRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /**
+         * Optional field used for concurrency control. One can ensure that the update operation will only be performed if the
+         * player's properties have not been updated by any other clients since last the version.
+         */
+        ExpectedPropertiesVersion?: number,
+        /** Unique PlayFab assigned ID of the user on whom the operation will be performed. */
+        PlayFabId: string,
+        /** Collection of properties to be set for a player. */
+        Properties: UpdateProperty[],
+    }
+
+    interface UpdatePlayerCustomPropertiesResult {
+        /** PlayFab unique identifier of the user whose properties were updated. */
+        PlayFabId?: string,
+        /**
+         * Indicates the current version of a player's properties that have been set. This is incremented after updates and
+         * deletes. This version can be provided in update and delete calls for concurrency control.
+         */
+        PropertiesVersion: number,
+    }
+
+    /**
      * This operation is additive. Statistics not currently defined will be added, while those already defined will be updated
      * with the given values. All other user statistics will remain unchanged.
      */
@@ -4279,6 +4998,13 @@ declare namespace PlayFabServerModels {
     }
 
     interface UpdatePlayerStatisticsResult {
+    }
+
+    interface UpdateProperty {
+        /** Name of the custom property. Can contain Unicode letters and digits. They are limited in size. */
+        Name: string,
+        /** Value of the custom property. Limited to booleans, numbers, and strings. */
+        Value: any,
     }
 
     /**
@@ -4395,6 +5121,8 @@ declare namespace PlayFabServerModels {
         AndroidDeviceInfo?: UserAndroidDeviceInfo,
         /** Sign in with Apple account information, if an Apple account has been linked */
         AppleAccountInfo?: UserAppleIdInfo,
+        /** Battle.net account information, if a Battle.net account has been linked */
+        BattleNetAccountInfo?: UserBattleNetInfo,
         /** Timestamp indicating when the user account was created */
         Created: string,
         /** Custom ID information, if a custom ID has been assigned */
@@ -4407,6 +5135,8 @@ declare namespace PlayFabServerModels {
         GameCenterInfo?: UserGameCenterInfo,
         /** User Google account information, if a Google account has been linked */
         GoogleInfo?: UserGoogleInfo,
+        /** User Google Play Games account information, if a Google Play Games account has been linked */
+        GooglePlayGamesInfo?: UserGooglePlayGamesInfo,
         /** User iOS device information, if an iOS device has been linked */
         IosDeviceInfo?: UserIosDeviceInfo,
         /** User Kongregate account information, if a Kongregate account has been linked */
@@ -4421,8 +5151,10 @@ declare namespace PlayFabServerModels {
         PlayFabId?: string,
         /** Personal information for the user which is considered more sensitive */
         PrivateInfo?: UserPrivateAccountInfo,
-        /** User PSN account information, if a PSN account has been linked */
+        /** User PlayStation :tm: Network account information, if a PlayStation :tm: Network account has been linked */
         PsnInfo?: UserPsnInfo,
+        /** Server Custom ID information, if a server custom ID has been assigned */
+        ServerCustomIdInfo?: UserServerCustomIdInfo,
         /** User Steam information, if a Steam account has been linked */
         SteamInfo?: UserSteamInfo,
         /** Title-specific information for the user account */
@@ -4445,6 +5177,13 @@ declare namespace PlayFabServerModels {
         AppleSubjectId?: string,
     }
 
+    interface UserBattleNetInfo {
+        /** Battle.net identifier */
+        BattleNetAccountId?: string,
+        /** Battle.net display name */
+        BattleNetBattleTag?: string,
+    }
+
     interface UserCustomIdInfo {
         /** Custom ID */
         CustomId?: string,
@@ -4455,6 +5194,7 @@ declare namespace PlayFabServerModels {
      * player makes a GetUserData request about another player, only keys marked Public will be returned.
      */
     type UserDataPermission = "Private"
+
         | "Public";
 
     interface UserDataRecord {
@@ -4481,6 +5221,11 @@ declare namespace PlayFabServerModels {
         FacebookInstantGamesId?: string,
     }
 
+    type UserFamilyType = "None"
+
+        | "Xbox"
+        | "Steam";
+
     interface UserGameCenterInfo {
         /** Gamecenter identifier */
         GameCenterId?: string,
@@ -4497,6 +5242,15 @@ declare namespace PlayFabServerModels {
         GoogleLocale?: string,
         /** Name of the Google account user */
         GoogleName?: string,
+    }
+
+    interface UserGooglePlayGamesInfo {
+        /** Avatar image url of the Google Play Games player */
+        GooglePlayGamesPlayerAvatarImageUrl?: string,
+        /** Display name of the Google Play Games player */
+        GooglePlayGamesPlayerDisplayName?: string,
+        /** Google Play Games player ID */
+        GooglePlayGamesPlayerId?: string,
     }
 
     interface UserIosDeviceInfo {
@@ -4531,6 +5285,7 @@ declare namespace PlayFabServerModels {
     }
 
     type UserOrigination = "Organic"
+
         | "Steam"
         | "Google"
         | "Amazon"
@@ -4560,10 +5315,15 @@ declare namespace PlayFabServerModels {
     }
 
     interface UserPsnInfo {
-        /** PSN account ID */
+        /** PlayStation :tm: Network account ID */
         PsnAccountId?: string,
-        /** PSN online ID */
+        /** PlayStation :tm: Network online ID */
         PsnOnlineId?: string,
+    }
+
+    interface UserServerCustomIdInfo {
+        /** Custom ID */
+        CustomId?: string,
     }
 
     interface UserSettings {
@@ -4745,7 +5505,8 @@ declare namespace PlayFabServerModels {
 /** Server interface methods */
 interface IPlayFabServerAPI {
     /**
-     * Increments the character's balance of the specified virtual currency by the stated amount
+     * _NOTE: This is a Legacy Economy API, and is in bugfix-only mode. All new Economy features are being developed only for
+     * version 2._ Increments the character's balance of the specified virtual currency by the stated amount
      * https://docs.microsoft.com/rest/api/playfab/server/player-item-management/addcharactervirtualcurrency
      */
     AddCharacterVirtualCurrency(request: PlayFabServerModels.AddCharacterVirtualCurrencyRequest): PlayFabServerModels.ModifyCharacterVirtualCurrencyResult;
@@ -4766,6 +5527,12 @@ interface IPlayFabServerAPI {
     AddGenericID(request: PlayFabServerModels.AddGenericIDRequest): PlayFabServerModels.EmptyResult;
 
     /**
+     * Adds or updates a contact email to the specified player's profile.
+     * https://docs.microsoft.com/rest/api/playfab/server/account-management/addorupdatecontactemail
+     */
+    AddOrUpdateContactEmail(request: PlayFabServerModels.AddOrUpdateContactEmailRequest): PlayFabServerModels.AddOrUpdateContactEmailResult;
+
+    /**
      * Adds a given tag to a player profile. The tag's namespace is automatically generated based on the source of the tag.
      * https://docs.microsoft.com/rest/api/playfab/server/playstream/addplayertag
      */
@@ -4781,7 +5548,8 @@ interface IPlayFabServerAPI {
     AddSharedGroupMembers(request: PlayFabServerModels.AddSharedGroupMembersRequest): PlayFabServerModels.AddSharedGroupMembersResult;
 
     /**
-     * Increments the user's balance of the specified virtual currency by the stated amount
+     * _NOTE: This is a Legacy Economy API, and is in bugfix-only mode. All new Economy features are being developed only for
+     * version 2._ Increments the user's balance of the specified virtual currency by the stated amount
      * https://docs.microsoft.com/rest/api/playfab/server/player-item-management/adduservirtualcurrency
      */
     AddUserVirtualCurrency(request: PlayFabServerModels.AddUserVirtualCurrencyRequest): PlayFabServerModels.ModifyUserVirtualCurrencyResult;
@@ -4799,13 +5567,15 @@ interface IPlayFabServerAPI {
     AwardSteamAchievement(request: PlayFabServerModels.AwardSteamAchievementRequest): PlayFabServerModels.AwardSteamAchievementResult;
 
     /**
-     * Bans users by PlayFab ID with optional IP address, or MAC address for the provided game.
+     * Bans users by PlayFab ID with optional IP address for the provided game.
      * https://docs.microsoft.com/rest/api/playfab/server/account-management/banusers
      */
     BanUsers(request: PlayFabServerModels.BanUsersRequest): PlayFabServerModels.BanUsersResult;
 
     /**
-     * Consume uses of a consumable item. When all uses are consumed, it will be removed from the player's inventory.
+     * _NOTE: This is a Legacy Economy API, and is in bugfix-only mode. All new Economy features are being developed only for
+     * version 2._ Consume uses of a consumable item. When all uses are consumed, it will be removed from the player's
+     * inventory.
      * https://docs.microsoft.com/rest/api/playfab/server/player-item-management/consumeitem
      */
     ConsumeItem(request: PlayFabServerModels.ConsumeItemRequest): PlayFabServerModels.ConsumeItemResult;
@@ -4832,6 +5602,12 @@ interface IPlayFabServerAPI {
     DeletePlayer(request: PlayFabServerModels.DeletePlayerRequest): PlayFabServerModels.DeletePlayerResult;
 
     /**
+     * Deletes title-specific custom properties for a player
+     * https://docs.microsoft.com/rest/api/playfab/server/player-data-management/deleteplayercustomproperties
+     */
+    DeletePlayerCustomProperties(request: PlayFabServerModels.DeletePlayerCustomPropertiesRequest): PlayFabServerModels.DeletePlayerCustomPropertiesResult;
+
+    /**
      * Deletes push notification template for title
      * https://docs.microsoft.com/rest/api/playfab/server/account-management/deletepushnotificationtemplate
      */
@@ -4846,14 +5622,10 @@ interface IPlayFabServerAPI {
     DeleteSharedGroup(request: PlayFabServerModels.DeleteSharedGroupRequest): PlayFabServerModels.EmptyResponse;
 
     /**
-     * Inform the matchmaker that a Game Server Instance is removed.
-     * https://docs.microsoft.com/rest/api/playfab/server/matchmaking/deregistergame
-     */
-    DeregisterGame(request: PlayFabServerModels.DeregisterGameRequest): PlayFabServerModels.DeregisterGameResponse;
-
-    /**
-     * Returns the result of an evaluation of a Random Result Table - the ItemId from the game Catalog which would have been
-     * added to the player inventory, if the Random Result Table were added via a Bundle or a call to UnlockContainer.
+     * _NOTE: This is a Legacy Economy API, and is in bugfix-only mode. All new Economy features are being developed only for
+     * version 2._ Returns the result of an evaluation of a Random Result Table - the ItemId from the game Catalog which would
+     * have been added to the player inventory, if the Random Result Table were added via a Bundle or a call to
+     * UnlockContainer.
      * https://docs.microsoft.com/rest/api/playfab/server/player-item-management/evaluaterandomresulttable
      */
     EvaluateRandomResultTable(request: PlayFabServerModels.EvaluateRandomResultTableRequest): PlayFabServerModels.EvaluateRandomResultTableResult;
@@ -4880,7 +5652,8 @@ interface IPlayFabServerAPI {
     GetAllUsersCharacters(request: PlayFabServerModels.ListUsersCharactersRequest): PlayFabServerModels.ListUsersCharactersResult;
 
     /**
-     * Retrieves the specified version of the title's catalog of virtual goods, including all defined properties
+     * _NOTE: This is a Legacy Economy API, and is in bugfix-only mode. All new Economy features are being developed only for
+     * version 2._ Retrieves the specified version of the title's catalog of virtual goods, including all defined properties
      * https://docs.microsoft.com/rest/api/playfab/server/title-wide-data-management/getcatalogitems
      */
     GetCatalogItems(request: PlayFabServerModels.GetCatalogItemsRequest): PlayFabServerModels.GetCatalogItemsResult;
@@ -4898,7 +5671,8 @@ interface IPlayFabServerAPI {
     GetCharacterInternalData(request: PlayFabServerModels.GetCharacterDataRequest): PlayFabServerModels.GetCharacterDataResult;
 
     /**
-     * Retrieves the specified character's current inventory of virtual goods
+     * _NOTE: This is a Legacy Economy API, and is in bugfix-only mode. All new Economy features are being developed only for
+     * version 2._ Retrieves the specified character's current inventory of virtual goods
      * https://docs.microsoft.com/rest/api/playfab/server/player-item-management/getcharacterinventory
      */
     GetCharacterInventory(request: PlayFabServerModels.GetCharacterInventoryRequest): PlayFabServerModels.GetCharacterInventoryResult;
@@ -4978,6 +5752,12 @@ interface IPlayFabServerAPI {
     GetPlayerCombinedInfo(request: PlayFabServerModels.GetPlayerCombinedInfoRequest): PlayFabServerModels.GetPlayerCombinedInfoResult;
 
     /**
+     * Retrieves a title-specific custom property value for a player.
+     * https://docs.microsoft.com/rest/api/playfab/server/player-data-management/getplayercustomproperty
+     */
+    GetPlayerCustomProperty(request: PlayFabServerModels.GetPlayerCustomPropertyRequest): PlayFabServerModels.GetPlayerCustomPropertyResult;
+
+    /**
      * Retrieves the player's profile
      * https://docs.microsoft.com/rest/api/playfab/server/account-management/getplayerprofile
      */
@@ -5018,6 +5798,12 @@ interface IPlayFabServerAPI {
     GetPlayerTags(request: PlayFabServerModels.GetPlayerTagsRequest): PlayFabServerModels.GetPlayerTagsResult;
 
     /**
+     * Retrieves the unique PlayFab identifiers for the given set of Battle.net account identifiers.
+     * https://docs.microsoft.com/rest/api/playfab/server/account-management/getplayfabidsfrombattlenetaccountids
+     */
+    GetPlayFabIDsFromBattleNetAccountIds(request: PlayFabServerModels.GetPlayFabIDsFromBattleNetAccountIdsRequest): PlayFabServerModels.GetPlayFabIDsFromBattleNetAccountIdsResult;
+
+    /**
      * Retrieves the unique PlayFab identifiers for the given set of Facebook identifiers.
      * https://docs.microsoft.com/rest/api/playfab/server/account-management/getplayfabidsfromfacebookids
      */
@@ -5050,10 +5836,24 @@ interface IPlayFabServerAPI {
     GetPlayFabIDsFromNintendoSwitchDeviceIds(request: PlayFabServerModels.GetPlayFabIDsFromNintendoSwitchDeviceIdsRequest): PlayFabServerModels.GetPlayFabIDsFromNintendoSwitchDeviceIdsResult;
 
     /**
-     * Retrieves the unique PlayFab identifiers for the given set of PlayStation Network identifiers.
+     * Retrieves the unique PlayFab identifiers for the given set of OpenId subject identifiers. A OpenId subject identifier is
+     * the OpenId issuer plus the OpenId subject for the player, as specified by the title when the OpenId identifier was added
+     * to the player account.
+     * https://docs.microsoft.com/rest/api/playfab/server/account-management/getplayfabidsfromopenidsubjectidentifiers
+     */
+    GetPlayFabIDsFromOpenIdSubjectIdentifiers(request: PlayFabServerModels.GetPlayFabIDsFromOpenIdsRequest): PlayFabServerModels.GetPlayFabIDsFromOpenIdsResult;
+
+    /**
+     * Retrieves the unique PlayFab identifiers for the given set of PlayStation :tm: Network identifiers.
      * https://docs.microsoft.com/rest/api/playfab/server/account-management/getplayfabidsfrompsnaccountids
      */
     GetPlayFabIDsFromPSNAccountIDs(request: PlayFabServerModels.GetPlayFabIDsFromPSNAccountIDsRequest): PlayFabServerModels.GetPlayFabIDsFromPSNAccountIDsResult;
+
+    /**
+     * Retrieves the unique PlayFab identifiers for the given set of PlayStation :tm: Network identifiers.
+     * https://docs.microsoft.com/rest/api/playfab/server/account-management/getplayfabidsfrompsnonlineids
+     */
+    GetPlayFabIDsFromPSNOnlineIDs(request: PlayFabServerModels.GetPlayFabIDsFromPSNOnlineIDsRequest): PlayFabServerModels.GetPlayFabIDsFromPSNOnlineIDsResult;
 
     /**
      * Retrieves the unique PlayFab identifiers for the given set of Steam identifiers. The Steam identifiers are the profile
@@ -5061,6 +5861,21 @@ interface IPlayFabServerAPI {
      * https://docs.microsoft.com/rest/api/playfab/server/account-management/getplayfabidsfromsteamids
      */
     GetPlayFabIDsFromSteamIDs(request: PlayFabServerModels.GetPlayFabIDsFromSteamIDsRequest): PlayFabServerModels.GetPlayFabIDsFromSteamIDsResult;
+
+    /**
+     * Retrieves the unique PlayFab identifiers for the given set of Steam identifiers. The Steam identifiers are persona
+     * names.
+     * https://docs.microsoft.com/rest/api/playfab/server/account-management/getplayfabidsfromsteamnames
+     */
+    GetPlayFabIDsFromSteamNames(request: PlayFabServerModels.GetPlayFabIDsFromSteamNamesRequest): PlayFabServerModels.GetPlayFabIDsFromSteamNamesResult;
+
+    /**
+     * Retrieves the unique PlayFab identifiers for the given set of Twitch identifiers. The Twitch identifiers are the IDs for
+     * the user accounts, available as "_id" from the Twitch API methods (ex:
+     * https://github.com/justintv/Twitch-API/blob/master/v3_resources/users.md#get-usersuser).
+     * https://docs.microsoft.com/rest/api/playfab/server/account-management/getplayfabidsfromtwitchids
+     */
+    GetPlayFabIDsFromTwitchIDs(request: PlayFabServerModels.GetPlayFabIDsFromTwitchIDsRequest): PlayFabServerModels.GetPlayFabIDsFromTwitchIDsResult;
 
     /**
      * Retrieves the unique PlayFab identifiers for the given set of XboxLive identifiers.
@@ -5075,8 +5890,9 @@ interface IPlayFabServerAPI {
     GetPublisherData(request: PlayFabServerModels.GetPublisherDataRequest): PlayFabServerModels.GetPublisherDataResult;
 
     /**
-     * Retrieves the configuration information for the specified random results tables for the title, including all ItemId
-     * values and weights
+     * _NOTE: This is a Legacy Economy API, and is in bugfix-only mode. All new Economy features are being developed only for
+     * version 2._ Retrieves the configuration information for the specified random results tables for the title, including all
+     * ItemId values and weights
      * https://docs.microsoft.com/rest/api/playfab/server/player-item-management/getrandomresulttables
      */
     GetRandomResultTables(request: PlayFabServerModels.GetRandomResultTablesRequest): PlayFabServerModels.GetRandomResultTablesResult;
@@ -5096,7 +5912,9 @@ interface IPlayFabServerAPI {
     GetSharedGroupData(request: PlayFabServerModels.GetSharedGroupDataRequest): PlayFabServerModels.GetSharedGroupDataResult;
 
     /**
-     * Retrieves the set of items defined for the specified store, including all prices defined, for the specified player
+     * _NOTE: This is a Legacy Economy API, and is in bugfix-only mode. All new Economy features are being developed only for
+     * version 2._ Retrieves the set of items defined for the specified store, including all prices defined, for the specified
+     * player
      * https://docs.microsoft.com/rest/api/playfab/server/title-wide-data-management/getstoreitems
      */
     GetStoreItems(request: PlayFabServerModels.GetStoreItemsServerRequest): PlayFabServerModels.GetStoreItemsResult;
@@ -5150,7 +5968,8 @@ interface IPlayFabServerAPI {
     GetUserInternalData(request: PlayFabServerModels.GetUserDataRequest): PlayFabServerModels.GetUserDataResult;
 
     /**
-     * Retrieves the specified user's current inventory of virtual goods
+     * _NOTE: This is a Legacy Economy API, and is in bugfix-only mode. All new Economy features are being developed only for
+     * version 2._ Retrieves the specified user's current inventory of virtual goods
      * https://docs.microsoft.com/rest/api/playfab/server/player-item-management/getuserinventory
      */
     GetUserInventory(request: PlayFabServerModels.GetUserInventoryRequest): PlayFabServerModels.GetUserInventoryResult;
@@ -5187,28 +6006,61 @@ interface IPlayFabServerAPI {
     GrantCharacterToUser(request: PlayFabServerModels.GrantCharacterToUserRequest): PlayFabServerModels.GrantCharacterToUserResult;
 
     /**
-     * Adds the specified items to the specified character's inventory
+     * _NOTE: This is a Legacy Economy API, and is in bugfix-only mode. All new Economy features are being developed only for
+     * version 2._ Adds the specified items to the specified character's inventory
      * https://docs.microsoft.com/rest/api/playfab/server/player-item-management/grantitemstocharacter
      */
     GrantItemsToCharacter(request: PlayFabServerModels.GrantItemsToCharacterRequest): PlayFabServerModels.GrantItemsToCharacterResult;
 
     /**
-     * Adds the specified items to the specified user's inventory
+     * _NOTE: This is a Legacy Economy API, and is in bugfix-only mode. All new Economy features are being developed only for
+     * version 2._ Adds the specified items to the specified user's inventory
      * https://docs.microsoft.com/rest/api/playfab/server/player-item-management/grantitemstouser
      */
     GrantItemsToUser(request: PlayFabServerModels.GrantItemsToUserRequest): PlayFabServerModels.GrantItemsToUserResult;
 
     /**
-     * Adds the specified items to the specified user inventories
+     * _NOTE: This is a Legacy Economy API, and is in bugfix-only mode. All new Economy features are being developed only for
+     * version 2._ Adds the specified items to the specified user inventories
      * https://docs.microsoft.com/rest/api/playfab/server/player-item-management/grantitemstousers
      */
     GrantItemsToUsers(request: PlayFabServerModels.GrantItemsToUsersRequest): PlayFabServerModels.GrantItemsToUsersResult;
 
     /**
-     * Links the PlayStation Network account associated with the provided access code to the user's PlayFab account
+     * Links the Battle.net account associated with the token to the user's PlayFab account.
+     * https://docs.microsoft.com/rest/api/playfab/server/account-management/linkbattlenetaccount
+     */
+    LinkBattleNetAccount(request: PlayFabServerModels.LinkBattleNetAccountRequest): PlayFabServerModels.EmptyResult;
+
+    /**
+     * Links the Nintendo account associated with the token to the user's PlayFab account
+     * https://docs.microsoft.com/rest/api/playfab/server/account-management/linknintendoserviceaccount
+     */
+    LinkNintendoServiceAccount(request: PlayFabServerModels.LinkNintendoServiceAccountRequest): PlayFabServerModels.EmptyResult;
+
+    /**
+     * Links the Nintendo account associated with the Nintendo Service Account subject or id to the user's PlayFab account
+     * https://docs.microsoft.com/rest/api/playfab/server/account-management/linknintendoserviceaccountsubject
+     */
+    LinkNintendoServiceAccountSubject(request: PlayFabServerModels.LinkNintendoServiceAccountSubjectRequest): PlayFabServerModels.EmptyResult;
+
+    /**
+     * Links the NintendoSwitchDeviceId to the user's PlayFab account
+     * https://docs.microsoft.com/rest/api/playfab/server/account-management/linknintendoswitchdeviceid
+     */
+    LinkNintendoSwitchDeviceId(request: PlayFabServerModels.LinkNintendoSwitchDeviceIdRequest): PlayFabServerModels.LinkNintendoSwitchDeviceIdResult;
+
+    /**
+     * Links the PlayStation :tm: Network account associated with the provided access code to the user's PlayFab account
      * https://docs.microsoft.com/rest/api/playfab/server/account-management/linkpsnaccount
      */
     LinkPSNAccount(request: PlayFabServerModels.LinkPSNAccountRequest): PlayFabServerModels.LinkPSNAccountResult;
+
+    /**
+     * Links the PlayStation :tm: Network account associated with the provided user id to the user's PlayFab account
+     * https://docs.microsoft.com/rest/api/playfab/server/account-management/linkpsnid
+     */
+    LinkPSNId(request: PlayFabServerModels.LinkPSNIdRequest): PlayFabServerModels.LinkPSNIdResponse;
 
     /**
      * Links the custom server identifier, generated by the title, to the user's PlayFab account.
@@ -5217,10 +6069,68 @@ interface IPlayFabServerAPI {
     LinkServerCustomId(request: PlayFabServerModels.LinkServerCustomIdRequest): PlayFabServerModels.LinkServerCustomIdResult;
 
     /**
+     * Links the Steam account associated with the provided Steam ID to the user's PlayFab account
+     * https://docs.microsoft.com/rest/api/playfab/server/account-management/linksteamid
+     */
+    LinkSteamId(request: PlayFabServerModels.LinkSteamIdRequest): PlayFabServerModels.LinkSteamIdResult;
+
+    /**
+     * Links the Twitch account associated with the token to the user's PlayFab account.
+     * https://docs.microsoft.com/rest/api/playfab/server/account-management/linktwitchaccount
+     */
+    LinkTwitchAccount(request: PlayFabServerModels.LinkTwitchAccountRequest): PlayFabServerModels.EmptyResult;
+
+    /**
      * Links the Xbox Live account associated with the provided access code to the user's PlayFab account
      * https://docs.microsoft.com/rest/api/playfab/server/account-management/linkxboxaccount
      */
     LinkXboxAccount(request: PlayFabServerModels.LinkXboxAccountRequest): PlayFabServerModels.LinkXboxAccountResult;
+
+    /**
+     * Links the Xbox Live account associated with the provided Xbox ID and Sandbox to the user's PlayFab account
+     * https://docs.microsoft.com/rest/api/playfab/server/account-management/linkxboxid
+     */
+    LinkXboxId(request: PlayFabServerModels.LinkXboxIdRequest): PlayFabServerModels.LinkXboxAccountResult;
+
+    /**
+     * Retrieves title-specific custom property values for a player.
+     * https://docs.microsoft.com/rest/api/playfab/server/player-data-management/listplayercustomproperties
+     */
+    ListPlayerCustomProperties(request: PlayFabServerModels.ListPlayerCustomPropertiesRequest): PlayFabServerModels.ListPlayerCustomPropertiesResult;
+
+    /**
+     * Signs the user in using the Android device identifier, returning a session identifier that can subsequently be used for
+     * API calls which require an authenticated user
+     * https://docs.microsoft.com/rest/api/playfab/server/authentication/loginwithandroiddeviceid
+     */
+    LoginWithAndroidDeviceID(request: PlayFabServerModels.LoginWithAndroidDeviceIDRequest): PlayFabServerModels.ServerLoginResult;
+
+    /**
+     * Sign in the user with a Battle.net identity token
+     * https://docs.microsoft.com/rest/api/playfab/server/authentication/loginwithbattlenet
+     */
+    LoginWithBattleNet(request: PlayFabServerModels.LoginWithBattleNetRequest): PlayFabServerModels.ServerLoginResult;
+
+    /**
+     * Signs the user in using a custom unique identifier generated by the title, returning a session identifier that can
+     * subsequently be used for API calls which require an authenticated user
+     * https://docs.microsoft.com/rest/api/playfab/server/authentication/loginwithcustomid
+     */
+    LoginWithCustomID(request: PlayFabServerModels.LoginWithCustomIDRequest): PlayFabServerModels.ServerLoginResult;
+
+    /**
+     * Signs the user in using the iOS device identifier, returning a session identifier that can subsequently be used for API
+     * calls which require an authenticated user
+     * https://docs.microsoft.com/rest/api/playfab/server/authentication/loginwithiosdeviceid
+     */
+    LoginWithIOSDeviceID(request: PlayFabServerModels.LoginWithIOSDeviceIDRequest): PlayFabServerModels.ServerLoginResult;
+
+    /**
+     * Signs the user in using a PlayStation :tm: Network authentication code, returning a session identifier that can
+     * subsequently be used for API calls which require an authenticated user
+     * https://docs.microsoft.com/rest/api/playfab/server/authentication/loginwithpsn
+     */
+    LoginWithPSN(request: PlayFabServerModels.LoginWithPSNRequest): PlayFabServerModels.ServerLoginResult;
 
     /**
      * Securely login a game client from an external server backend using a custom identifier for that player. Server Custom ID
@@ -5237,6 +6147,12 @@ interface IPlayFabServerAPI {
     LoginWithSteamId(request: PlayFabServerModels.LoginWithSteamIdRequest): PlayFabServerModels.ServerLoginResult;
 
     /**
+     * Sign in the user with a Twitch access token
+     * https://docs.microsoft.com/rest/api/playfab/server/authentication/loginwithtwitch
+     */
+    LoginWithTwitch(request: PlayFabServerModels.LoginWithTwitchRequest): PlayFabServerModels.ServerLoginResult;
+
+    /**
      * Signs the user in using a Xbox Live Token from an external server backend, returning a session identifier that can
      * subsequently be used for API calls which require an authenticated user
      * https://docs.microsoft.com/rest/api/playfab/server/authentication/loginwithxbox
@@ -5251,59 +6167,40 @@ interface IPlayFabServerAPI {
     LoginWithXboxId(request: PlayFabServerModels.LoginWithXboxIdRequest): PlayFabServerModels.ServerLoginResult;
 
     /**
-     * Modifies the number of remaining uses of a player's inventory item
+     * _NOTE: This is a Legacy Economy API, and is in bugfix-only mode. All new Economy features are being developed only for
+     * version 2._ Modifies the number of remaining uses of a player's inventory item
      * https://docs.microsoft.com/rest/api/playfab/server/player-item-management/modifyitemuses
      */
     ModifyItemUses(request: PlayFabServerModels.ModifyItemUsesRequest): PlayFabServerModels.ModifyItemUsesResult;
 
     /**
-     * Moves an item from a character's inventory into another of the users's character's inventory.
+     * _NOTE: This is a Legacy Economy API, and is in bugfix-only mode. All new Economy features are being developed only for
+     * version 2._ Moves an item from a character's inventory into another of the users's character's inventory.
      * https://docs.microsoft.com/rest/api/playfab/server/player-item-management/moveitemtocharacterfromcharacter
      */
     MoveItemToCharacterFromCharacter(request: PlayFabServerModels.MoveItemToCharacterFromCharacterRequest): PlayFabServerModels.MoveItemToCharacterFromCharacterResult;
 
     /**
-     * Moves an item from a user's inventory into their character's inventory.
+     * _NOTE: This is a Legacy Economy API, and is in bugfix-only mode. All new Economy features are being developed only for
+     * version 2._ Moves an item from a user's inventory into their character's inventory.
      * https://docs.microsoft.com/rest/api/playfab/server/player-item-management/moveitemtocharacterfromuser
      */
     MoveItemToCharacterFromUser(request: PlayFabServerModels.MoveItemToCharacterFromUserRequest): PlayFabServerModels.MoveItemToCharacterFromUserResult;
 
     /**
-     * Moves an item from a character's inventory into the owning user's inventory.
+     * _NOTE: This is a Legacy Economy API, and is in bugfix-only mode. All new Economy features are being developed only for
+     * version 2._ Moves an item from a character's inventory into the owning user's inventory.
      * https://docs.microsoft.com/rest/api/playfab/server/player-item-management/moveitemtouserfromcharacter
      */
     MoveItemToUserFromCharacter(request: PlayFabServerModels.MoveItemToUserFromCharacterRequest): PlayFabServerModels.MoveItemToUserFromCharacterResult;
 
     /**
-     * Informs the PlayFab match-making service that the user specified has left the Game Server Instance
-     * https://docs.microsoft.com/rest/api/playfab/server/matchmaking/notifymatchmakerplayerleft
-     */
-    NotifyMatchmakerPlayerLeft(request: PlayFabServerModels.NotifyMatchmakerPlayerLeftRequest): PlayFabServerModels.NotifyMatchmakerPlayerLeftResult;
-
-    /**
-     * Adds the virtual goods associated with the coupon to the user's inventory. Coupons can be generated via the
+     * _NOTE: This is a Legacy Economy API, and is in bugfix-only mode. All new Economy features are being developed only for
+     * version 2._ Adds the virtual goods associated with the coupon to the user's inventory. Coupons can be generated via the
      * Economy-&gt;Catalogs tab in the PlayFab Game Manager.
      * https://docs.microsoft.com/rest/api/playfab/server/player-item-management/redeemcoupon
      */
     RedeemCoupon(request: PlayFabServerModels.RedeemCouponRequest): PlayFabServerModels.RedeemCouponResult;
-
-    /**
-     * Validates a Game Server session ticket and returns details about the user
-     * https://docs.microsoft.com/rest/api/playfab/server/matchmaking/redeemmatchmakerticket
-     */
-    RedeemMatchmakerTicket(request: PlayFabServerModels.RedeemMatchmakerTicketRequest): PlayFabServerModels.RedeemMatchmakerTicketResult;
-
-    /**
-     * Set the state of the indicated Game Server Instance. Also update the heartbeat for the instance.
-     * https://docs.microsoft.com/rest/api/playfab/server/matchmaking/refreshgameserverinstanceheartbeat
-     */
-    RefreshGameServerInstanceHeartbeat(request: PlayFabServerModels.RefreshGameServerInstanceHeartbeatRequest): PlayFabServerModels.RefreshGameServerInstanceHeartbeatResult;
-
-    /**
-     * Inform the matchmaker that a new Game Server Instance is added.
-     * https://docs.microsoft.com/rest/api/playfab/server/matchmaking/registergame
-     */
-    RegisterGame(request: PlayFabServerModels.RegisterGameRequest): PlayFabServerModels.RegisterGameResponse;
 
     /**
      * Removes the specified friend from the the user's friend list
@@ -5352,13 +6249,15 @@ interface IPlayFabServerAPI {
     RevokeBans(request: PlayFabServerModels.RevokeBansRequest): PlayFabServerModels.RevokeBansResult;
 
     /**
-     * Revokes access to an item in a user's inventory
+     * _NOTE: This is a Legacy Economy API, and is in bugfix-only mode. All new Economy features are being developed only for
+     * version 2._ Revokes access to an item in a user's inventory
      * https://docs.microsoft.com/rest/api/playfab/server/player-item-management/revokeinventoryitem
      */
     RevokeInventoryItem(request: PlayFabServerModels.RevokeInventoryItemRequest): PlayFabServerModels.RevokeInventoryResult;
 
     /**
-     * Revokes access for up to 25 items across multiple users and characters.
+     * _NOTE: This is a Legacy Economy API, and is in bugfix-only mode. All new Economy features are being developed only for
+     * version 2._ Revokes access for up to 25 items across multiple users and characters.
      * https://docs.microsoft.com/rest/api/playfab/server/player-item-management/revokeinventoryitems
      */
     RevokeInventoryItems(request: PlayFabServerModels.RevokeInventoryItemsRequest): PlayFabServerModels.RevokeInventoryItemsResult;
@@ -5403,24 +6302,6 @@ interface IPlayFabServerAPI {
     SetFriendTags(request: PlayFabServerModels.SetFriendTagsRequest): PlayFabServerModels.EmptyResponse;
 
     /**
-     * Sets the custom data of the indicated Game Server Instance
-     * https://docs.microsoft.com/rest/api/playfab/server/matchmaking/setgameserverinstancedata
-     */
-    SetGameServerInstanceData(request: PlayFabServerModels.SetGameServerInstanceDataRequest): PlayFabServerModels.SetGameServerInstanceDataResult;
-
-    /**
-     * Set the state of the indicated Game Server Instance.
-     * https://docs.microsoft.com/rest/api/playfab/server/matchmaking/setgameserverinstancestate
-     */
-    SetGameServerInstanceState(request: PlayFabServerModels.SetGameServerInstanceStateRequest): PlayFabServerModels.SetGameServerInstanceStateResult;
-
-    /**
-     * Set custom tags for the specified Game Server Instance
-     * https://docs.microsoft.com/rest/api/playfab/server/matchmaking/setgameserverinstancetags
-     */
-    SetGameServerInstanceTags(request: PlayFabServerModels.SetGameServerInstanceTagsRequest): PlayFabServerModels.SetGameServerInstanceTagsResult;
-
-    /**
      * Sets the player's secret if it is not already set. Player secrets are used to sign API requests. To reset a player's
      * secret use the Admin or Server API method SetPlayerSecret.
      * https://docs.microsoft.com/rest/api/playfab/server/authentication/setplayersecret
@@ -5446,21 +6327,53 @@ interface IPlayFabServerAPI {
     SetTitleInternalData(request: PlayFabServerModels.SetTitleDataRequest): PlayFabServerModels.SetTitleDataResult;
 
     /**
-     * Decrements the character's balance of the specified virtual currency by the stated amount. It is possible to make a VC
-     * balance negative with this API.
+     * _NOTE: This is a Legacy Economy API, and is in bugfix-only mode. All new Economy features are being developed only for
+     * version 2._ Decrements the character's balance of the specified virtual currency by the stated amount. It is possible to
+     * make a VC balance negative with this API.
      * https://docs.microsoft.com/rest/api/playfab/server/player-item-management/subtractcharactervirtualcurrency
      */
     SubtractCharacterVirtualCurrency(request: PlayFabServerModels.SubtractCharacterVirtualCurrencyRequest): PlayFabServerModels.ModifyCharacterVirtualCurrencyResult;
 
     /**
-     * Decrements the user's balance of the specified virtual currency by the stated amount. It is possible to make a VC
-     * balance negative with this API.
+     * _NOTE: This is a Legacy Economy API, and is in bugfix-only mode. All new Economy features are being developed only for
+     * version 2._ Decrements the user's balance of the specified virtual currency by the stated amount. It is possible to make
+     * a VC balance negative with this API.
      * https://docs.microsoft.com/rest/api/playfab/server/player-item-management/subtractuservirtualcurrency
      */
     SubtractUserVirtualCurrency(request: PlayFabServerModels.SubtractUserVirtualCurrencyRequest): PlayFabServerModels.ModifyUserVirtualCurrencyResult;
 
     /**
-     * Unlinks the related PSN account from the user's PlayFab account
+     * Unlinks the related Battle.net account from the user's PlayFab account.
+     * https://docs.microsoft.com/rest/api/playfab/server/account-management/unlinkbattlenetaccount
+     */
+    UnlinkBattleNetAccount(request: PlayFabServerModels.UnlinkBattleNetAccountRequest): PlayFabServerModels.EmptyResponse;
+
+    /**
+     * Unlinks the related Facebook account from the user's PlayFab account
+     * https://docs.microsoft.com/rest/api/playfab/server/account-management/unlinkfacebookaccount
+     */
+    UnlinkFacebookAccount(request: PlayFabServerModels.UnlinkFacebookAccountRequest): PlayFabServerModels.UnlinkFacebookAccountResult;
+
+    /**
+     * Unlinks the related Facebook Instant Games identifier from the user's PlayFab account
+     * https://docs.microsoft.com/rest/api/playfab/server/account-management/unlinkfacebookinstantgamesid
+     */
+    UnlinkFacebookInstantGamesId(request: PlayFabServerModels.UnlinkFacebookInstantGamesIdRequest): PlayFabServerModels.UnlinkFacebookInstantGamesIdResult;
+
+    /**
+     * Unlinks the related Nintendo account from the user's PlayFab account
+     * https://docs.microsoft.com/rest/api/playfab/server/account-management/unlinknintendoserviceaccount
+     */
+    UnlinkNintendoServiceAccount(request: PlayFabServerModels.UnlinkNintendoServiceAccountRequest): PlayFabServerModels.EmptyResponse;
+
+    /**
+     * Unlinks the related NintendoSwitchDeviceId from the user's PlayFab account
+     * https://docs.microsoft.com/rest/api/playfab/server/account-management/unlinknintendoswitchdeviceid
+     */
+    UnlinkNintendoSwitchDeviceId(request: PlayFabServerModels.UnlinkNintendoSwitchDeviceIdRequest): PlayFabServerModels.UnlinkNintendoSwitchDeviceIdResult;
+
+    /**
+     * Unlinks the related PlayStation :tm: Network account from the user's PlayFab account
      * https://docs.microsoft.com/rest/api/playfab/server/account-management/unlinkpsnaccount
      */
     UnlinkPSNAccount(request: PlayFabServerModels.UnlinkPSNAccountRequest): PlayFabServerModels.UnlinkPSNAccountResult;
@@ -5472,23 +6385,37 @@ interface IPlayFabServerAPI {
     UnlinkServerCustomId(request: PlayFabServerModels.UnlinkServerCustomIdRequest): PlayFabServerModels.UnlinkServerCustomIdResult;
 
     /**
+     * Unlinks the Steam account associated with the provided Steam ID to the user's PlayFab account
+     * https://docs.microsoft.com/rest/api/playfab/server/account-management/unlinksteamid
+     */
+    UnlinkSteamId(request: PlayFabServerModels.UnlinkSteamIdRequest): PlayFabServerModels.UnlinkSteamIdResult;
+
+    /**
+     * Unlinks the related Twitch account from the user's PlayFab account.
+     * https://docs.microsoft.com/rest/api/playfab/server/account-management/unlinktwitchaccount
+     */
+    UnlinkTwitchAccount(request: PlayFabServerModels.UnlinkTwitchAccountRequest): PlayFabServerModels.EmptyResult;
+
+    /**
      * Unlinks the related Xbox Live account from the user's PlayFab account
      * https://docs.microsoft.com/rest/api/playfab/server/account-management/unlinkxboxaccount
      */
     UnlinkXboxAccount(request: PlayFabServerModels.UnlinkXboxAccountRequest): PlayFabServerModels.UnlinkXboxAccountResult;
 
     /**
-     * Opens a specific container (ContainerItemInstanceId), with a specific key (KeyItemInstanceId, when required), and
-     * returns the contents of the opened container. If the container (and key when relevant) are consumable (RemainingUses &gt;
-     * 0), their RemainingUses will be decremented, consistent with the operation of ConsumeItem.
+     * _NOTE: This is a Legacy Economy API, and is in bugfix-only mode. All new Economy features are being developed only for
+     * version 2._ Opens a specific container (ContainerItemInstanceId), with a specific key (KeyItemInstanceId, when
+     * required), and returns the contents of the opened container. If the container (and key when relevant) are consumable
+     * (RemainingUses &gt; 0), their RemainingUses will be decremented, consistent with the operation of ConsumeItem.
      * https://docs.microsoft.com/rest/api/playfab/server/player-item-management/unlockcontainerinstance
      */
     UnlockContainerInstance(request: PlayFabServerModels.UnlockContainerInstanceRequest): PlayFabServerModels.UnlockContainerItemResult;
 
     /**
-     * Searches Player or Character inventory for any ItemInstance matching the given CatalogItemId, if necessary unlocks it
-     * using any appropriate key, and returns the contents of the opened container. If the container (and key when relevant)
-     * are consumable (RemainingUses &gt; 0), their RemainingUses will be decremented, consistent with the operation of
+     * _NOTE: This is a Legacy Economy API, and is in bugfix-only mode. All new Economy features are being developed only for
+     * version 2._ Searches Player or Character inventory for any ItemInstance matching the given CatalogItemId, if necessary
+     * unlocks it using any appropriate key, and returns the contents of the opened container. If the container (and key when
+     * relevant) are consumable (RemainingUses &gt; 0), their RemainingUses will be decremented, consistent with the operation of
      * ConsumeItem.
      * https://docs.microsoft.com/rest/api/playfab/server/player-item-management/unlockcontaineritem
      */
@@ -5531,6 +6458,12 @@ interface IPlayFabServerAPI {
     UpdateCharacterStatistics(request: PlayFabServerModels.UpdateCharacterStatisticsRequest): PlayFabServerModels.UpdateCharacterStatisticsResult;
 
     /**
+     * Updates the title-specific custom property values for a player
+     * https://docs.microsoft.com/rest/api/playfab/server/player-data-management/updateplayercustomproperties
+     */
+    UpdatePlayerCustomProperties(request: PlayFabServerModels.UpdatePlayerCustomPropertiesRequest): PlayFabServerModels.UpdatePlayerCustomPropertiesResult;
+
+    /**
      * Updates the values of the specified title-specific statistics for the user
      * https://docs.microsoft.com/rest/api/playfab/server/player-data-management/updateplayerstatistics
      */
@@ -5559,7 +6492,8 @@ interface IPlayFabServerAPI {
     UpdateUserInternalData(request: PlayFabServerModels.UpdateUserInternalDataRequest): PlayFabServerModels.UpdateUserDataResult;
 
     /**
-     * Updates the key-value pair data tagged to the specified item, which is read-only from the client.
+     * _NOTE: This is a Legacy Economy API, and is in bugfix-only mode. All new Economy features are being developed only for
+     * version 2._ Updates the key-value pair data tagged to the specified item, which is read-only from the client.
      * https://docs.microsoft.com/rest/api/playfab/server/player-item-management/updateuserinventoryitemcustomdata
      */
     UpdateUserInventoryItemCustomData(request: PlayFabServerModels.UpdateUserInventoryItemDataRequest): PlayFabServerModels.EmptyResponse;
@@ -5612,6 +6546,38 @@ interface IPlayFabServerAPI {
 
 /** AuthenticationAPI.Models as interfaces */
 declare namespace PlayFabAuthenticationModels {
+    /** Create or return a game_server entity token. Caller must be a title entity. */
+    interface AuthenticateCustomIdRequest {
+        /**
+         * The customId used to create and retrieve game_server entity tokens. This is unique at the title level. CustomId must be
+         * between 32 and 100 characters.
+         */
+        CustomId: string,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+    }
+
+    interface AuthenticateCustomIdResult {
+        /** The token generated used to set X-EntityToken for game_server calls. */
+        EntityToken?: EntityTokenResponse,
+        /** True if the account was newly created on this authentication. */
+        NewlyCreated: boolean,
+    }
+
+    /**
+     * Delete a game_server entity. The caller can be the game_server entity attempting to delete itself. Or a title entity
+     * attempting to delete game_server entities for this title.
+     */
+    interface DeleteRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The game_server entity to be removed. */
+        Entity: EntityKey,
+    }
+
+    interface EmptyResponse {
+    }
+
     /** Combined entity type and ID structure which uniquely identifies a single entity. */
     interface EntityKey {
         /** Unique ID of the entity. */
@@ -5633,6 +6599,15 @@ declare namespace PlayFabAuthenticationModels {
         TitleId?: string,
         /** The Title Player Account Id of the associated entity. */
         TitlePlayerAccountId?: string,
+    }
+
+    interface EntityTokenResponse {
+        /** The entity id and type. */
+        Entity?: EntityKey,
+        /** The token used to set X-EntityToken for all entity based API calls. */
+        EntityToken?: string,
+        /** The time the token will expire, if it is an expiring token, in UTC. */
+        TokenExpiration?: string,
     }
 
     /**
@@ -5659,10 +6634,19 @@ declare namespace PlayFabAuthenticationModels {
     }
 
     type IdentifiedDeviceType = "Unknown"
+
         | "XboxOne"
-        | "Scarlett";
+        | "Scarlett"
+        | "WindowsOneCore"
+        | "WindowsOneCoreMobile"
+        | "Win32"
+        | "android"
+        | "iOS"
+        | "PlayStation"
+        | "Nintendo";
 
     type LoginIdentityProvider = "Unknown"
+
         | "PlayFab"
         | "Custom"
         | "GameCenter"
@@ -5884,6 +6868,7 @@ declare namespace PlayFabDataModels {
     }
 
     type OperationTypes = "Created"
+
         | "Updated"
         | "Deleted"
         | "None";
@@ -5946,6 +6931,115 @@ declare namespace PlayFabDataModels {
 }
 /** EventsAPI.Models as interfaces */
 declare namespace PlayFabEventsModels {
+    interface CreateTelemetryKeyRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
+        Entity?: EntityKey,
+        /** The name of the new key. Telemetry key names must be unique within the scope of the title. */
+        KeyName: string,
+    }
+
+    interface CreateTelemetryKeyResponse {
+        /** Details about the newly created telemetry key. */
+        NewKeyDetails?: TelemetryKeyDetails,
+    }
+
+    interface DataConnectionAzureBlobSettings {
+        /** Name of the storage account. */
+        AccountName?: string,
+        /** Name of the container. */
+        ContainerName?: string,
+        /** Azure Entra Tenant Id. */
+        TenantId?: string,
+    }
+
+    interface DataConnectionAzureDataExplorerSettings {
+        /** The URI of the ADX cluster. */
+        ClusterUri?: string,
+        /** The database to write to. */
+        Database?: string,
+        /** The table to write to. */
+        Table?: string,
+    }
+
+    interface DataConnectionDetails {
+        /** Settings of the data connection. */
+        ConnectionSettings: DataConnectionSettings,
+        /** Whether or not the connection is currently active. */
+        IsActive: boolean,
+        /** The name of the data connection. */
+        Name: string,
+        /** Current status of the data connection, if any. */
+        Status?: DataConnectionStatusDetails,
+        /** The type of data connection. */
+        Type: DataConnectionType,
+    }
+
+    type DataConnectionErrorState = "OK"
+
+        | "Error";
+
+    interface DataConnectionFabricKQLSettings {
+        /** The URI of the Fabric cluster. */
+        ClusterUri?: string,
+        /** The database to write to. */
+        Database?: string,
+        /** The table to write to. */
+        Table?: string,
+    }
+
+    interface DataConnectionSettings {
+        /** Settings if the type of connection is AzureBlobStorage. */
+        AzureBlobSettings?: DataConnectionAzureBlobSettings,
+        /** Settings if the type of connection is AzureDataExplorer. */
+        AzureDataExplorerSettings?: DataConnectionAzureDataExplorerSettings,
+        /** Settings if the type of connection is FabricKQL. */
+        AzureFabricKQLSettings?: DataConnectionFabricKQLSettings,
+    }
+
+    interface DataConnectionStatusDetails {
+        /** The name of the error affecting the data connection, if any. */
+        Error?: string,
+        /** A description of the error affecting the data connection, if any. This may be empty for some errors. */
+        ErrorMessage?: string,
+        /** The most recent time of the error affecting the data connection, if any. */
+        MostRecentErrorTime?: string,
+        /** Indicates if the connection is in a normal state or error state. */
+        State?: DataConnectionErrorState,
+    }
+
+    type DataConnectionType = "AzureBlobStorage"
+
+        | "AzureDataExplorer"
+        | "FabricKQL";
+
+    interface DeleteDataConnectionRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The name of the data connection to delete. */
+        Name: string,
+    }
+
+    interface DeleteDataConnectionResponse {
+        /** Indicates whether or not the connection was deleted as part of the request. */
+        WasDeleted: boolean,
+    }
+
+    interface DeleteTelemetryKeyRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
+        Entity?: EntityKey,
+        /** The name of the key to delete. */
+        KeyName: string,
+    }
+
+    interface DeleteTelemetryKeyResponse {
+        /** Indicates whether or not the key was deleted. If false, no key with that name existed. */
+        WasKeyDeleted: boolean,
+    }
+
     /** Combined entity type and ID structure which uniquely identifies a single entity. */
     interface EntityKey {
         /** Unique ID of the entity. */
@@ -5986,10 +7080,126 @@ declare namespace PlayFabEventsModels {
         PayloadJSON?: string,
     }
 
+    interface GetDataConnectionRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The name of the data connection to retrieve. */
+        Name: string,
+    }
+
+    interface GetDataConnectionResponse {
+        /** The details of the queried Data Connection. */
+        DataConnection?: DataConnectionDetails,
+    }
+
+    interface GetTelemetryKeyRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
+        Entity?: EntityKey,
+        /** The name of the key to retrieve. */
+        KeyName: string,
+    }
+
+    interface GetTelemetryKeyResponse {
+        /** Details about the requested telemetry key. */
+        KeyDetails?: TelemetryKeyDetails,
+    }
+
+    interface ListDataConnectionsRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+    }
+
+    interface ListDataConnectionsResponse {
+        /** The list of existing Data Connections. */
+        DataConnections?: DataConnectionDetails[],
+    }
+
+    interface ListTelemetryKeysRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
+        Entity?: EntityKey,
+    }
+
+    interface ListTelemetryKeysResponse {
+        /** The telemetry keys configured for the title. */
+        KeyDetails?: TelemetryKeyDetails[],
+    }
+
+    interface SetDataConnectionActiveRequest {
+        /** Whether to set the data connection to active (true) or deactivated (false). */
+        Active: boolean,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The name of the data connection to update. */
+        Name: string,
+    }
+
+    interface SetDataConnectionActiveResponse {
+        /** The most current details about the data connection that was to be updated. */
+        DataConnection?: DataConnectionDetails,
+        /**
+         * Indicates whether or not the data connection was updated. If false, the data connection was already in the desired
+         * state.
+         */
+        WasUpdated: boolean,
+    }
+
+    interface SetDataConnectionRequest {
+        /** Settings of the data connection. */
+        ConnectionSettings: DataConnectionSettings,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** Whether or not the connection is currently active. */
+        IsActive: boolean,
+        /** The name of the data connection to update or create. */
+        Name: string,
+        /** The type of data connection. */
+        Type: DataConnectionType,
+    }
+
+    interface SetDataConnectionResponse {
+        /** The details of the Data Connection to be created or updated. */
+        DataConnection?: DataConnectionDetails,
+    }
+
+    interface SetTelemetryKeyActiveRequest {
+        /** Whether to set the key to active (true) or deactivated (false). */
+        Active: boolean,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
+        Entity?: EntityKey,
+        /** The name of the key to update. */
+        KeyName: string,
+    }
+
+    interface SetTelemetryKeyActiveResponse {
+        /** The most current details about the telemetry key that was to be updated. */
+        KeyDetails?: TelemetryKeyDetails,
+        /** Indicates whether or not the key was updated. If false, the key was already in the desired state. */
+        WasKeyUpdated: boolean,
+    }
+
+    interface TelemetryKeyDetails {
+        /** When the key was created. */
+        CreateTime: string,
+        /** Whether or not the key is currently active. Deactivated keys cannot be used for telemetry ingestion. */
+        IsActive: boolean,
+        /** The key that can be distributed to clients for use during telemetry ingestion. */
+        KeyValue?: string,
+        /** When the key was last updated. */
+        LastUpdateTime: string,
+        /** The name of the key. Telemetry key names are unique within the scope of the title. */
+        Name?: string,
+    }
+
     interface WriteEventsRequest {
         /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
         CustomTags?: { [key: string]: string | null },
-        /** Collection of events to write to PlayStream. */
+        /** The collection of events to write. Up to 200 events can be written per request. */
         Events: EventContents[],
     }
 
@@ -6161,7 +7371,7 @@ declare namespace PlayFabGroupsModels {
         Group: EntityKey,
         /**
          * The ID of the role. This must be unique within the group and cannot be changed. Role IDs must be between 1 and 64
-         * characters long.
+         * characters long and are restricted to a-Z, A-Z, 0-9, '(', ')', '_', '-' and '.'.
          */
         RoleId: string,
         /**
@@ -6469,6 +7679,7 @@ declare namespace PlayFabGroupsModels {
     }
 
     type OperationTypes = "Created"
+
         | "Updated"
         | "Deleted"
         | "None";
@@ -6590,6 +7801,7 @@ declare namespace PlayFabGroupsModels {
 /** ProfilesAPI.Models as interfaces */
 declare namespace PlayFabProfilesModels {
     type EffectType = "Allow"
+
         | "Deny";
 
     /** An entity object and its associated meta data. */
@@ -6660,8 +7872,6 @@ declare namespace PlayFabProfilesModels {
         Files?: { [key: string]: EntityProfileFileMetadata },
         /** The language on this profile. */
         Language?: string,
-        /** Leaderboard metadata for the entity. */
-        LeaderboardMetadata?: string,
         /** The lineage of this profile. */
         Lineage?: EntityLineage,
         /** The objects on this profile. */
@@ -6692,24 +7902,13 @@ declare namespace PlayFabProfilesModels {
         Size: number,
     }
 
-    interface EntityStatisticChildValue {
-        /** Child name value, if child statistic */
-        ChildName?: string,
-        /** Child statistic metadata */
-        Metadata?: string,
-        /** Child statistic value */
-        Value: number,
-    }
-
     interface EntityStatisticValue {
-        /** Child statistic values */
-        ChildStatistics?: { [key: string]: EntityStatisticChildValue },
-        /** Statistic metadata */
+        /** Metadata associated with the Statistic. */
         Metadata?: string,
         /** Statistic name */
         Name?: string,
-        /** Statistic value */
-        Value?: number,
+        /** Statistic scores */
+        Scores?: string[],
         /** Statistic version */
         Version: number,
     }
@@ -6792,10 +7991,53 @@ declare namespace PlayFabProfilesModels {
         TitlePlayerAccounts?: { [key: string]: EntityKey },
     }
 
+    interface GetTitlePlayersFromProviderIDsResponse {
+        /**
+         * Dictionary of provider identifiers mapped to title_player_account lineage. Missing lineage indicates the player either
+         * doesn't exist or doesn't play the requested title.
+         */
+        TitlePlayerAccounts?: { [key: string]: EntityLineage },
+    }
+
+    /** Given a collection of Xbox IDs (XUIDs), returns all title player accounts. */
+    interface GetTitlePlayersFromXboxLiveIDsRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** Xbox Sandbox the players had on their Xbox tokens. */
+        Sandbox: string,
+        /** Optional ID of title to get players from, required if calling using a master_player_account. */
+        TitleId?: string,
+        /** List of Xbox Live XUIDs */
+        XboxLiveIds: string[],
+    }
+
     type OperationTypes = "Created"
+
         | "Updated"
         | "Deleted"
         | "None";
+
+    /**
+     * Given an entity profile, will update its display name to the one passed in if the profile's version is equal to the
+     * specified value
+     */
+    interface SetDisplayNameRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The new value to be set on Entity Profile's display name */
+        DisplayName?: string,
+        /** The optional entity to perform this action on. Defaults to the currently logged in entity. */
+        Entity?: EntityKey,
+        /** The expected version of a profile to perform this update on */
+        ExpectedVersion?: number,
+    }
+
+    interface SetDisplayNameResponse {
+        /** The type of operation that occured on the profile's display name */
+        OperationResult?: OperationTypes,
+        /** The updated version of the profile after the display name update */
+        VersionNumber?: number,
+    }
 
     /**
      * This will set the access policy statements on the given entity profile. This is not additive, any existing statements
@@ -6807,7 +8049,7 @@ declare namespace PlayFabProfilesModels {
         /** The entity to perform this action on. */
         Entity: EntityKey,
         /** The statements to include in the access policy. */
-        Statements?: EntityPermissionStatement[],
+        Statements: EntityPermissionStatement[],
     }
 
     interface SetEntityProfilePolicyResponse {
@@ -6858,6 +8100,18 @@ declare namespace PlayFabProfilesModels {
 
 /** Entity interface methods */
 interface IPlayFabEntityAPI {
+
+    /**
+     * Create a game_server entity token and return a new or existing game_server entity.
+     * https://docs.microsoft.com/rest/api/playfab/authentication/authentication/authenticategameserverwithcustomid
+     */
+    AuthenticateGameServerWithCustomId(request: PlayFabAuthenticationModels.AuthenticateCustomIdRequest): PlayFabAuthenticationModels.AuthenticateCustomIdResult;
+
+    /**
+     * Delete a game_server entity.
+     * https://docs.microsoft.com/rest/api/playfab/authentication/authentication/delete
+     */
+    Delete(request: PlayFabAuthenticationModels.DeleteRequest): PlayFabAuthenticationModels.EmptyResponse;
 
     /**
      * Method to exchange a legacy AuthenticationTicket or title SecretKey for an Entity Token or to refresh a still valid
@@ -6915,6 +8169,66 @@ interface IPlayFabEntityAPI {
      */
     SetObjects(request: PlayFabDataModels.SetObjectsRequest): PlayFabDataModels.SetObjectsResponse;
 
+
+    /**
+     * Creates a new telemetry key for the title.
+     * https://docs.microsoft.com/rest/api/playfab/events/playstream-events/createtelemetrykey
+     */
+    CreateTelemetryKey(request: PlayFabEventsModels.CreateTelemetryKeyRequest): PlayFabEventsModels.CreateTelemetryKeyResponse;
+
+    /**
+     * Deletes a Data Connection from a title.
+     * https://docs.microsoft.com/rest/api/playfab/events/playstream-events/deletedataconnection
+     */
+    DeleteDataConnection(request: PlayFabEventsModels.DeleteDataConnectionRequest): PlayFabEventsModels.DeleteDataConnectionResponse;
+
+    /**
+     * Deletes a telemetry key configured for the title.
+     * https://docs.microsoft.com/rest/api/playfab/events/playstream-events/deletetelemetrykey
+     */
+    DeleteTelemetryKey(request: PlayFabEventsModels.DeleteTelemetryKeyRequest): PlayFabEventsModels.DeleteTelemetryKeyResponse;
+
+    /**
+     * Retrieves a single Data Connection associated with a title.
+     * https://docs.microsoft.com/rest/api/playfab/events/playstream-events/getdataconnection
+     */
+    GetDataConnection(request: PlayFabEventsModels.GetDataConnectionRequest): PlayFabEventsModels.GetDataConnectionResponse;
+
+    /**
+     * Gets information about a telemetry key configured for the title.
+     * https://docs.microsoft.com/rest/api/playfab/events/playstream-events/gettelemetrykey
+     */
+    GetTelemetryKey(request: PlayFabEventsModels.GetTelemetryKeyRequest): PlayFabEventsModels.GetTelemetryKeyResponse;
+
+    /**
+     * Retrieves the list of Data Connections associated with a title.
+     * https://docs.microsoft.com/rest/api/playfab/events/playstream-events/listdataconnections
+     */
+    ListDataConnections(request: PlayFabEventsModels.ListDataConnectionsRequest): PlayFabEventsModels.ListDataConnectionsResponse;
+
+    /**
+     * Lists all telemetry keys configured for the title.
+     * https://docs.microsoft.com/rest/api/playfab/events/playstream-events/listtelemetrykeys
+     */
+    ListTelemetryKeys(request: PlayFabEventsModels.ListTelemetryKeysRequest): PlayFabEventsModels.ListTelemetryKeysResponse;
+
+    /**
+     * Creates or updates a Data Connection on a title.
+     * https://docs.microsoft.com/rest/api/playfab/events/playstream-events/setdataconnection
+     */
+    SetDataConnection(request: PlayFabEventsModels.SetDataConnectionRequest): PlayFabEventsModels.SetDataConnectionResponse;
+
+    /**
+     * Sets a Data Connection for the title to either the active or deactivated state.
+     * https://docs.microsoft.com/rest/api/playfab/events/playstream-events/setdataconnectionactive
+     */
+    SetDataConnectionActive(request: PlayFabEventsModels.SetDataConnectionActiveRequest): PlayFabEventsModels.SetDataConnectionActiveResponse;
+
+    /**
+     * Sets a telemetry key to the active or deactivated state.
+     * https://docs.microsoft.com/rest/api/playfab/events/playstream-events/settelemetrykeyactive
+     */
+    SetTelemetryKeyActive(request: PlayFabEventsModels.SetTelemetryKeyActiveRequest): PlayFabEventsModels.SetTelemetryKeyActiveResponse;
 
     /**
      * Write batches of entity based events to PlayStream. The namespace of the Event must be 'custom' or start with 'custom.'.
@@ -7106,6 +8420,18 @@ interface IPlayFabEntityAPI {
     GetTitlePlayersFromMasterPlayerAccountIds(request: PlayFabProfilesModels.GetTitlePlayersFromMasterPlayerAccountIdsRequest): PlayFabProfilesModels.GetTitlePlayersFromMasterPlayerAccountIdsResponse;
 
     /**
+     * Retrieves the title player accounts associated with the given XUIDs.
+     * https://docs.microsoft.com/rest/api/playfab/profiles/account-management/gettitleplayersfromxboxliveids
+     */
+    GetTitlePlayersFromXboxLiveIDs(request: PlayFabProfilesModels.GetTitlePlayersFromXboxLiveIDsRequest): PlayFabProfilesModels.GetTitlePlayersFromProviderIDsResponse;
+
+    /**
+     * Update the display name of the entity
+     * https://docs.microsoft.com/rest/api/playfab/profiles/account-management/setdisplayname
+     */
+    SetDisplayName(request: PlayFabProfilesModels.SetDisplayNameRequest): PlayFabProfilesModels.SetDisplayNameResponse;
+
+    /**
      * Sets the global title access policy
      * https://docs.microsoft.com/rest/api/playfab/profiles/account-management/setglobalpolicy
      */
@@ -7123,6 +8449,3830 @@ interface IPlayFabEntityAPI {
      * https://docs.microsoft.com/rest/api/playfab/profiles/account-management/setprofilepolicy
      */
     SetProfilePolicy(request: PlayFabProfilesModels.SetEntityProfilePolicyRequest): PlayFabProfilesModels.SetEntityProfilePolicyResponse;
+
+
+}
+
+
+/** MultiplayerAPI.Models as interfaces */
+declare namespace PlayFabMultiplayerModels {
+    type AccessPolicy = "Public"
+
+        | "Friends"
+        | "Private";
+
+    interface AssetReference {
+        /** The asset's file name. This is a filename with the .zip, .tar, or .tar.gz extension. */
+        FileName?: string,
+        /** The asset's mount path. */
+        MountPath?: string,
+    }
+
+    interface AssetReferenceParams {
+        /** The asset's file name. */
+        FileName: string,
+        /** The asset's mount path. */
+        MountPath?: string,
+    }
+
+    interface AssetSummary {
+        /** The asset's file name. This is a filename with the .zip, .tar, or .tar.gz extension. */
+        FileName?: string,
+        /** The metadata associated with the asset. */
+        Metadata?: { [key: string]: string | null },
+    }
+
+    type AttributeMergeFunction = "Min"
+
+        | "Max"
+        | "Average";
+
+    type AttributeNotSpecifiedBehavior = "UseDefault"
+
+        | "MatchAny";
+
+    type AttributeSource = "User"
+
+        | "PlayerEntity";
+
+    type AzureRegion = "AustraliaEast"
+
+        | "AustraliaSoutheast"
+        | "BrazilSouth"
+        | "CentralUs"
+        | "EastAsia"
+        | "EastUs"
+        | "EastUs2"
+        | "JapanEast"
+        | "JapanWest"
+        | "NorthCentralUs"
+        | "NorthEurope"
+        | "SouthCentralUs"
+        | "SoutheastAsia"
+        | "WestEurope"
+        | "WestUs"
+        | "SouthAfricaNorth"
+        | "WestCentralUs"
+        | "KoreaCentral"
+        | "FranceCentral"
+        | "WestUs2"
+        | "CentralIndia"
+        | "UaeNorth"
+        | "UkSouth"
+        | "SwedenCentral"
+        | "CanadaCentral"
+        | "MexicoCentral";
+
+    type AzureVmFamily = "A"
+
+        | "Av2"
+        | "Dv2"
+        | "Dv3"
+        | "F"
+        | "Fsv2"
+        | "Dasv4"
+        | "Dav4"
+        | "Dadsv5"
+        | "Dadsv6"
+        | "Eav4"
+        | "Easv4"
+        | "Ev4"
+        | "Esv4"
+        | "Dsv3"
+        | "Dsv2"
+        | "NCasT4_v3"
+        | "Ddv4"
+        | "Ddsv4"
+        | "HBv3"
+        | "Ddv5"
+        | "Ddsv5"
+        | "Ddsv6";
+
+    type AzureVmSize = "Standard_A1"
+
+        | "Standard_A2"
+        | "Standard_A3"
+        | "Standard_A4"
+        | "Standard_A1_v2"
+        | "Standard_A2_v2"
+        | "Standard_A4_v2"
+        | "Standard_A8_v2"
+        | "Standard_D1_v2"
+        | "Standard_D2_v2"
+        | "Standard_D3_v2"
+        | "Standard_D4_v2"
+        | "Standard_D5_v2"
+        | "Standard_D2_v3"
+        | "Standard_D4_v3"
+        | "Standard_D8_v3"
+        | "Standard_D16_v3"
+        | "Standard_F1"
+        | "Standard_F2"
+        | "Standard_F4"
+        | "Standard_F8"
+        | "Standard_F16"
+        | "Standard_F2s_v2"
+        | "Standard_F4s_v2"
+        | "Standard_F8s_v2"
+        | "Standard_F16s_v2"
+        | "Standard_D2as_v4"
+        | "Standard_D4as_v4"
+        | "Standard_D8as_v4"
+        | "Standard_D16as_v4"
+        | "Standard_D2a_v4"
+        | "Standard_D4a_v4"
+        | "Standard_D8a_v4"
+        | "Standard_D16a_v4"
+        | "Standard_D2ads_v5"
+        | "Standard_D4ads_v5"
+        | "Standard_D8ads_v5"
+        | "Standard_D16ads_v5"
+        | "Standard_D2ads_v6"
+        | "Standard_D4ads_v6"
+        | "Standard_D8ads_v6"
+        | "Standard_D16ads_v6"
+        | "Standard_E2a_v4"
+        | "Standard_E4a_v4"
+        | "Standard_E8a_v4"
+        | "Standard_E16a_v4"
+        | "Standard_E2as_v4"
+        | "Standard_E4as_v4"
+        | "Standard_E8as_v4"
+        | "Standard_E16as_v4"
+        | "Standard_D2s_v3"
+        | "Standard_D4s_v3"
+        | "Standard_D8s_v3"
+        | "Standard_D16s_v3"
+        | "Standard_DS1_v2"
+        | "Standard_DS2_v2"
+        | "Standard_DS3_v2"
+        | "Standard_DS4_v2"
+        | "Standard_DS5_v2"
+        | "Standard_NC4as_T4_v3"
+        | "Standard_D2d_v4"
+        | "Standard_D4d_v4"
+        | "Standard_D8d_v4"
+        | "Standard_D16d_v4"
+        | "Standard_D2ds_v4"
+        | "Standard_D4ds_v4"
+        | "Standard_D8ds_v4"
+        | "Standard_D16ds_v4"
+        | "Standard_HB120_16rs_v3"
+        | "Standard_HB120_32rs_v3"
+        | "Standard_HB120_64rs_v3"
+        | "Standard_HB120_96rs_v3"
+        | "Standard_HB120rs_v3"
+        | "Standard_D2d_v5"
+        | "Standard_D4d_v5"
+        | "Standard_D8d_v5"
+        | "Standard_D16d_v5"
+        | "Standard_D32d_v5"
+        | "Standard_D2ds_v5"
+        | "Standard_D4ds_v5"
+        | "Standard_D8ds_v5"
+        | "Standard_D16ds_v5"
+        | "Standard_D32ds_v5"
+        | "Standard_D2ds_v6"
+        | "Standard_D4ds_v6"
+        | "Standard_D8ds_v6"
+        | "Standard_D16ds_v6";
+
+    interface BuildAliasDetailsResponse {
+        /** The guid string alias Id of the alias to be created or updated. */
+        AliasId?: string,
+        /** The alias name. */
+        AliasName?: string,
+        /** Array of build selection criteria. */
+        BuildSelectionCriteria?: BuildSelectionCriterion[],
+    }
+
+    interface BuildAliasParams {
+        /** The guid string alias ID to use for the request. */
+        AliasId: string,
+    }
+
+    interface BuildRegion {
+        /** The current multiplayer server stats for the region. */
+        CurrentServerStats?: CurrentServerStats,
+        /** Optional settings to control dynamic adjustment of standby target */
+        DynamicStandbySettings?: DynamicStandbySettings,
+        /** Whether the game assets provided for the build have been replicated to this region. */
+        IsAssetReplicationComplete: boolean,
+        /** The maximum number of multiplayer servers for the region. */
+        MaxServers: number,
+        /** Regional override for the number of multiplayer servers to host on a single VM of the build. */
+        MultiplayerServerCountPerVm?: number,
+        /** The build region. */
+        Region?: string,
+        /** Optional settings to set the standby target to specified values during the supplied schedules */
+        ScheduledStandbySettings?: ScheduledStandbySettings,
+        /** The target number of standby multiplayer servers for the region. */
+        StandbyServers: number,
+        /**
+         * The status of multiplayer servers in the build region. Valid values are - Unknown, Initialized, Deploying, Deployed,
+         * Unhealthy, Deleting, Deleted.
+         */
+        Status?: string,
+        /** Regional override for the VM size the build was created on. */
+        VmSize?: AzureVmSize,
+    }
+
+    interface BuildRegionParams {
+        /** Optional settings to control dynamic adjustment of standby target. If not specified, dynamic standby is disabled */
+        DynamicStandbySettings?: DynamicStandbySettings,
+        /** The maximum number of multiplayer servers for the region. */
+        MaxServers: number,
+        /** Regional override for the number of multiplayer servers to host on a single VM of the build. */
+        MultiplayerServerCountPerVm?: number,
+        /** The build region. */
+        Region: string,
+        /** Optional settings to set the standby target to specified values during the supplied schedules */
+        ScheduledStandbySettings?: ScheduledStandbySettings,
+        /** The number of standby multiplayer servers for the region. */
+        StandbyServers: number,
+        /** Regional override for the VM size the build was created on. */
+        VmSize?: AzureVmSize,
+    }
+
+    interface BuildSelectionCriterion {
+        /** Dictionary of build ids and their respective weights for distribution of allocation requests. */
+        BuildWeightDistribution?: { [key: string]: number },
+    }
+
+    interface BuildSummary {
+        /** The guid string build ID of the build. */
+        BuildId?: string,
+        /** The build name. */
+        BuildName?: string,
+        /** The time the build was created in UTC. */
+        CreationTime?: string,
+        /** The metadata of the build. */
+        Metadata?: { [key: string]: string | null },
+        /** The configuration and status for each region in the build. */
+        RegionConfigurations?: BuildRegion[],
+    }
+
+    /**
+     * Cancels all tickets of which the player is a member in a given queue that are not cancelled or matched. This API is
+     * useful if you lose track of what tickets the player is a member of (if the title crashes for instance) and want to
+     * "reset". The Entity field is optional if the caller is a player and defaults to that player. Players may not cancel
+     * tickets for other people. The Entity field is required if the caller is a server (authenticated as the title).
+     */
+    interface CancelAllMatchmakingTicketsForPlayerRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The entity key of the player whose tickets should be canceled. */
+        Entity?: EntityKey,
+        /** The name of the queue from which a player's tickets should be canceled. */
+        QueueName: string,
+    }
+
+    interface CancelAllMatchmakingTicketsForPlayerResult {
+    }
+
+    /**
+     * Cancels all backfill tickets of which the player is a member in a given queue that are not cancelled or matched. This
+     * API is useful if you lose track of what tickets the player is a member of (if the server crashes for instance) and want
+     * to "reset".
+     */
+    interface CancelAllServerBackfillTicketsForPlayerRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The entity key of the player whose backfill tickets should be canceled. */
+        Entity: EntityKey,
+        /** The name of the queue from which a player's backfill tickets should be canceled. */
+        QueueName: string,
+    }
+
+    interface CancelAllServerBackfillTicketsForPlayerResult {
+    }
+
+    type CancellationReason = "Requested"
+
+        | "Internal"
+        | "Timeout";
+
+    /**
+     * Only servers and ticket members can cancel a ticket. The ticket can be in five different states when it is cancelled. 1:
+     * the ticket is waiting for members to join it, and it has not started matching. If the ticket is cancelled at this stage,
+     * it will never match. 2: the ticket is matching. If the ticket is cancelled, it will stop matching. 3: the ticket is
+     * matched. A matched ticket cannot be cancelled. 4: the ticket is already cancelled and nothing happens. 5: the ticket is
+     * waiting for a server. If the ticket is cancelled, server allocation will be stopped. A server may still be allocated due
+     * to a race condition, but that will not be reflected in the ticket. There may be race conditions between the ticket
+     * getting matched and the client making a cancellation request. The client must handle the possibility that the cancel
+     * request fails if a match is found before the cancellation request is processed. We do not allow resubmitting a cancelled
+     * ticket because players must consent to enter matchmaking again. Create a new ticket instead.
+     */
+    interface CancelMatchmakingTicketRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The name of the queue the ticket is in. */
+        QueueName: string,
+        /** The Id of the ticket to find a match for. */
+        TicketId: string,
+    }
+
+    interface CancelMatchmakingTicketResult {
+    }
+
+    /**
+     * Only servers can cancel a backfill ticket. The ticket can be in three different states when it is cancelled. 1: the
+     * ticket is matching. If the ticket is cancelled, it will stop matching. 2: the ticket is matched. A matched ticket cannot
+     * be cancelled. 3: the ticket is already cancelled and nothing happens. There may be race conditions between the ticket
+     * getting matched and the server making a cancellation request. The server must handle the possibility that the cancel
+     * request fails if a match is found before the cancellation request is processed. We do not allow resubmitting a cancelled
+     * ticket. Create a new ticket instead.
+     */
+    interface CancelServerBackfillTicketRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The name of the queue the ticket is in. */
+        QueueName: string,
+        /** The Id of the ticket to find a match for. */
+        TicketId: string,
+    }
+
+    interface CancelServerBackfillTicketResult {
+    }
+
+    interface Certificate {
+        /** Base64 encoded string contents of the certificate. */
+        Base64EncodedValue: string,
+        /** A name for the certificate. This is used to reference certificates in build configurations. */
+        Name: string,
+        /**
+         * If required for your PFX certificate, use this field to provide a password that will be used to install the certificate
+         * on the container.
+         */
+        Password?: string,
+    }
+
+    interface CertificateSummary {
+        /** The name of the certificate. */
+        Name?: string,
+        /** The thumbprint for the certificate. */
+        Thumbprint?: string,
+    }
+
+    interface ConnectedPlayer {
+        /** The player ID of the player connected to the multiplayer server. */
+        PlayerId?: string,
+    }
+
+    type ContainerFlavor = "ManagedWindowsServerCore"
+
+        | "CustomLinux"
+        | "ManagedWindowsServerCorePreview"
+        | "Invalid";
+
+    interface ContainerImageReference {
+        /** The container image name. */
+        ImageName: string,
+        /** The container tag. */
+        Tag?: string,
+    }
+
+    interface CoreCapacity {
+        /** The available core capacity for the (Region, VmFamily) */
+        Available: number,
+        /** The AzureRegion */
+        Region?: string,
+        /** The total core capacity for the (Region, VmFamily) */
+        Total: number,
+        /** The AzureVmFamily */
+        VmFamily?: AzureVmFamily,
+    }
+
+    interface CoreCapacityChange {
+        /** New quota core limit for the given vm family/region. */
+        NewCoreLimit: number,
+        /** Region to change. */
+        Region: string,
+        /** Virtual machine family to change. */
+        VmFamily: AzureVmFamily,
+    }
+
+    /** Creates a multiplayer server build alias and returns the created alias. */
+    interface CreateBuildAliasRequest {
+        /** The alias name. */
+        AliasName: string,
+        /** Array of build selection criteria. */
+        BuildSelectionCriteria?: BuildSelectionCriterion[],
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+    }
+
+    /** Creates a multiplayer server build with a custom container and returns information about the build creation request. */
+    interface CreateBuildWithCustomContainerRequest {
+        /**
+         * When true, assets will not be copied for each server inside the VM. All serverswill run from the same set of assets, or
+         * will have the same assets mounted in the container.
+         */
+        AreAssetsReadonly?: boolean,
+        /** The build name. */
+        BuildName: string,
+        /** The flavor of container to create a build from. */
+        ContainerFlavor?: ContainerFlavor,
+        /** The container reference, consisting of the image name and tag. */
+        ContainerImageReference?: ContainerImageReference,
+        /** The container command to run when the multiplayer server has been allocated, including any arguments. */
+        ContainerRunCommand?: string,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The list of game assets related to the build. */
+        GameAssetReferences?: AssetReferenceParams[],
+        /** The game certificates for the build. */
+        GameCertificateReferences?: GameCertificateReferenceParams[],
+        /** The game secrets for the build. */
+        GameSecretReferences?: GameSecretReferenceParams[],
+        /** The Linux instrumentation configuration for the build. */
+        LinuxInstrumentationConfiguration?: LinuxInstrumentationConfiguration,
+        /**
+         * Metadata to tag the build. The keys are case insensitive. The build metadata is made available to the server through
+         * Game Server SDK (GSDK).Constraints: Maximum number of keys: 30, Maximum key length: 50, Maximum value length: 100
+         */
+        Metadata?: { [key: string]: string | null },
+        /** The configuration for the monitoring application on the build */
+        MonitoringApplicationConfiguration?: MonitoringApplicationConfigurationParams,
+        /** The number of multiplayer servers to host on a single VM. */
+        MultiplayerServerCountPerVm: number,
+        /** The ports to map the build on. */
+        Ports: Port[],
+        /** The region configurations for the build. */
+        RegionConfigurations: BuildRegionParams[],
+        /** The resource constraints to apply to each server on the VM (EXPERIMENTAL API) */
+        ServerResourceConstraints?: ServerResourceConstraintParams,
+        /** The VM size to create the build on. */
+        VmSize?: AzureVmSize,
+        /** The configuration for the VmStartupScript for the build */
+        VmStartupScriptConfiguration?: VmStartupScriptParams,
+    }
+
+    interface CreateBuildWithCustomContainerResponse {
+        /**
+         * When true, assets will not be copied for each server inside the VM. All serverswill run from the same set of assets, or
+         * will have the same assets mounted in the container.
+         */
+        AreAssetsReadonly?: boolean,
+        /** The guid string build ID. Must be unique for every build. */
+        BuildId?: string,
+        /** The build name. */
+        BuildName?: string,
+        /** The flavor of container of the build. */
+        ContainerFlavor?: ContainerFlavor,
+        /** The container command to run when the multiplayer server has been allocated, including any arguments. */
+        ContainerRunCommand?: string,
+        /** The time the build was created in UTC. */
+        CreationTime?: string,
+        /** The custom game container image reference information. */
+        CustomGameContainerImage?: ContainerImageReference,
+        /** The game assets for the build. */
+        GameAssetReferences?: AssetReference[],
+        /** The game certificates for the build. */
+        GameCertificateReferences?: GameCertificateReference[],
+        /** The game secrets for the build. */
+        GameSecretReferences?: GameSecretReference[],
+        /** The Linux instrumentation configuration for this build. */
+        LinuxInstrumentationConfiguration?: LinuxInstrumentationConfiguration,
+        /** The metadata of the build. */
+        Metadata?: { [key: string]: string | null },
+        /** The configuration for the monitoring application for the build */
+        MonitoringApplicationConfiguration?: MonitoringApplicationConfiguration,
+        /** The number of multiplayer servers to host on a single VM of the build. */
+        MultiplayerServerCountPerVm: number,
+        /** The OS platform used for running the game process. */
+        OsPlatform?: string,
+        /** The ports the build is mapped on. */
+        Ports?: Port[],
+        /** The region configuration for the build. */
+        RegionConfigurations?: BuildRegion[],
+        /** The resource constraints to apply to each server on the VM (EXPERIMENTAL API) */
+        ServerResourceConstraints?: ServerResourceConstraintParams,
+        /** The type of game server being hosted. */
+        ServerType?: string,
+        /**
+         * When true, assets will be downloaded and uncompressed in memory, without the compressedversion being written first to
+         * disc.
+         */
+        UseStreamingForAssetDownloads?: boolean,
+        /** The VM size the build was created on. */
+        VmSize?: AzureVmSize,
+        /** The configuration for the VmStartupScript feature for the build */
+        VmStartupScriptConfiguration?: VmStartupScriptConfiguration,
+    }
+
+    /** Creates a multiplayer server build with a managed container and returns information about the build creation request. */
+    interface CreateBuildWithManagedContainerRequest {
+        /**
+         * When true, assets will not be copied for each server inside the VM. All serverswill run from the same set of assets, or
+         * will have the same assets mounted in the container.
+         */
+        AreAssetsReadonly?: boolean,
+        /** The build name. */
+        BuildName: string,
+        /** The flavor of container to create a build from. */
+        ContainerFlavor?: ContainerFlavor,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The list of game assets related to the build. */
+        GameAssetReferences: AssetReferenceParams[],
+        /** The game certificates for the build. */
+        GameCertificateReferences?: GameCertificateReferenceParams[],
+        /** The game secrets for the build. */
+        GameSecretReferences?: GameSecretReferenceParams[],
+        /**
+         * The directory containing the game executable. This would be the start path of the game assets that contain the main game
+         * server executable. If not provided, a best effort will be made to extract it from the start game command.
+         */
+        GameWorkingDirectory?: string,
+        /** The instrumentation configuration for the build. */
+        InstrumentationConfiguration?: InstrumentationConfiguration,
+        /**
+         * Metadata to tag the build. The keys are case insensitive. The build metadata is made available to the server through
+         * Game Server SDK (GSDK).Constraints: Maximum number of keys: 30, Maximum key length: 50, Maximum value length: 100
+         */
+        Metadata?: { [key: string]: string | null },
+        /** The configuration for the monitoring application on the build */
+        MonitoringApplicationConfiguration?: MonitoringApplicationConfigurationParams,
+        /** The number of multiplayer servers to host on a single VM. */
+        MultiplayerServerCountPerVm: number,
+        /** The ports to map the build on. */
+        Ports: Port[],
+        /** The region configurations for the build. */
+        RegionConfigurations: BuildRegionParams[],
+        /** The resource constraints to apply to each server on the VM (EXPERIMENTAL API) */
+        ServerResourceConstraints?: ServerResourceConstraintParams,
+        /** The command to run when the multiplayer server is started, including any arguments. */
+        StartMultiplayerServerCommand: string,
+        /** The VM size to create the build on. */
+        VmSize?: AzureVmSize,
+        /** The configuration for the VmStartupScript for the build */
+        VmStartupScriptConfiguration?: VmStartupScriptParams,
+        /** The crash dump configuration for the build. */
+        WindowsCrashDumpConfiguration?: WindowsCrashDumpConfiguration,
+    }
+
+    interface CreateBuildWithManagedContainerResponse {
+        /**
+         * When true, assets will not be copied for each server inside the VM. All serverswill run from the same set of assets, or
+         * will have the same assets mounted in the container.
+         */
+        AreAssetsReadonly?: boolean,
+        /** The guid string build ID. Must be unique for every build. */
+        BuildId?: string,
+        /** The build name. */
+        BuildName?: string,
+        /** The flavor of container of the build. */
+        ContainerFlavor?: ContainerFlavor,
+        /** The time the build was created in UTC. */
+        CreationTime?: string,
+        /** The game assets for the build. */
+        GameAssetReferences?: AssetReference[],
+        /** The game certificates for the build. */
+        GameCertificateReferences?: GameCertificateReference[],
+        /** The game secrets for the build. */
+        GameSecretReferences?: GameSecretReference[],
+        /**
+         * The directory containing the game executable. This would be the start path of the game assets that contain the main game
+         * server executable. If not provided, a best effort will be made to extract it from the start game command.
+         */
+        GameWorkingDirectory?: string,
+        /** The instrumentation configuration for this build. */
+        InstrumentationConfiguration?: InstrumentationConfiguration,
+        /** The metadata of the build. */
+        Metadata?: { [key: string]: string | null },
+        /** The configuration for the monitoring application for the build */
+        MonitoringApplicationConfiguration?: MonitoringApplicationConfiguration,
+        /** The number of multiplayer servers to host on a single VM of the build. */
+        MultiplayerServerCountPerVm: number,
+        /** The OS platform used for running the game process. */
+        OsPlatform?: string,
+        /** The ports the build is mapped on. */
+        Ports?: Port[],
+        /** The region configuration for the build. */
+        RegionConfigurations?: BuildRegion[],
+        /** The resource constraints to apply to each server on the VM (EXPERIMENTAL API) */
+        ServerResourceConstraints?: ServerResourceConstraintParams,
+        /** The type of game server being hosted. */
+        ServerType?: string,
+        /** The command to run when the multiplayer server has been allocated, including any arguments. */
+        StartMultiplayerServerCommand?: string,
+        /**
+         * When true, assets will be downloaded and uncompressed in memory, without the compressedversion being written first to
+         * disc.
+         */
+        UseStreamingForAssetDownloads?: boolean,
+        /** The VM size the build was created on. */
+        VmSize?: AzureVmSize,
+        /** The configuration for the VmStartupScript feature for the build */
+        VmStartupScriptConfiguration?: VmStartupScriptConfiguration,
+    }
+
+    /**
+     * Creates a multiplayer server build with the game server running as a process and returns information about the build
+     * creation request.
+     */
+    interface CreateBuildWithProcessBasedServerRequest {
+        /**
+         * When true, assets will not be copied for each server inside the VM. All serverswill run from the same set of assets, or
+         * will have the same assets mounted in the container.
+         */
+        AreAssetsReadonly?: boolean,
+        /** The build name. */
+        BuildName: string,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The list of game assets related to the build. */
+        GameAssetReferences: AssetReferenceParams[],
+        /** The game certificates for the build. */
+        GameCertificateReferences?: GameCertificateReferenceParams[],
+        /** The game secrets for the build. */
+        GameSecretReferences?: GameSecretReferenceParams[],
+        /**
+         * The working directory for the game process. If this is not provided, the working directory will be set based on the
+         * mount path of the game server executable.
+         */
+        GameWorkingDirectory?: string,
+        /** The instrumentation configuration for the Build. Used only if it is a Windows Build. */
+        InstrumentationConfiguration?: InstrumentationConfiguration,
+        /**
+         * Indicates whether this build will be created using the OS Preview versionPreview OS is recommended for dev builds to
+         * detect any breaking changes before they are released to retail. Retail builds should set this value to false.
+         */
+        IsOSPreview?: boolean,
+        /** The Linux instrumentation configuration for the Build. Used only if it is a Linux Build. */
+        LinuxInstrumentationConfiguration?: LinuxInstrumentationConfiguration,
+        /**
+         * Metadata to tag the build. The keys are case insensitive. The build metadata is made available to the server through
+         * Game Server SDK (GSDK).Constraints: Maximum number of keys: 30, Maximum key length: 50, Maximum value length: 100
+         */
+        Metadata?: { [key: string]: string | null },
+        /** The configuration for the monitoring application on the build */
+        MonitoringApplicationConfiguration?: MonitoringApplicationConfigurationParams,
+        /** The number of multiplayer servers to host on a single VM. */
+        MultiplayerServerCountPerVm: number,
+        /** The OS platform used for running the game process. */
+        OsPlatform?: string,
+        /** The ports to map the build on. */
+        Ports: Port[],
+        /** The region configurations for the build. */
+        RegionConfigurations: BuildRegionParams[],
+        /**
+         * The command to run when the multiplayer server is started, including any arguments. The path to any executable should be
+         * relative to the root asset folder when unzipped.
+         */
+        StartMultiplayerServerCommand: string,
+        /** The VM size to create the build on. */
+        VmSize?: AzureVmSize,
+        /** The configuration for the VmStartupScript for the build */
+        VmStartupScriptConfiguration?: VmStartupScriptParams,
+    }
+
+    interface CreateBuildWithProcessBasedServerResponse {
+        /**
+         * When true, assets will not be copied for each server inside the VM. All serverswill run from the same set of assets, or
+         * will have the same assets mounted in the container.
+         */
+        AreAssetsReadonly?: boolean,
+        /** The guid string build ID. Must be unique for every build. */
+        BuildId?: string,
+        /** The build name. */
+        BuildName?: string,
+        /** The flavor of container of the build. */
+        ContainerFlavor?: ContainerFlavor,
+        /** The time the build was created in UTC. */
+        CreationTime?: string,
+        /** The game assets for the build. */
+        GameAssetReferences?: AssetReference[],
+        /** The game certificates for the build. */
+        GameCertificateReferences?: GameCertificateReference[],
+        /** The game secrets for the build. */
+        GameSecretReferences?: GameSecretReference[],
+        /**
+         * The working directory for the game process. If this is not provided, the working directory will be set based on the
+         * mount path of the game server executable.
+         */
+        GameWorkingDirectory?: string,
+        /** The instrumentation configuration for this build. */
+        InstrumentationConfiguration?: InstrumentationConfiguration,
+        /**
+         * Indicates whether this build will be created using the OS Preview versionPreview OS is recommended for dev builds to
+         * detect any breaking changes before they are released to retail. Retail builds should set this value to false.
+         */
+        IsOSPreview?: boolean,
+        /** The Linux instrumentation configuration for this build. */
+        LinuxInstrumentationConfiguration?: LinuxInstrumentationConfiguration,
+        /** The metadata of the build. */
+        Metadata?: { [key: string]: string | null },
+        /** The configuration for the monitoring application for the build */
+        MonitoringApplicationConfiguration?: MonitoringApplicationConfiguration,
+        /** The number of multiplayer servers to host on a single VM of the build. */
+        MultiplayerServerCountPerVm: number,
+        /** The OS platform used for running the game process. */
+        OsPlatform?: string,
+        /** The ports the build is mapped on. */
+        Ports?: Port[],
+        /** The region configuration for the build. */
+        RegionConfigurations?: BuildRegion[],
+        /** The type of game server being hosted. */
+        ServerType?: string,
+        /**
+         * The command to run when the multiplayer server is started, including any arguments. The path to any executable is
+         * relative to the root asset folder when unzipped.
+         */
+        StartMultiplayerServerCommand?: string,
+        /**
+         * When true, assets will be downloaded and uncompressed in memory, without the compressedversion being written first to
+         * disc.
+         */
+        UseStreamingForAssetDownloads?: boolean,
+        /** The VM size the build was created on. */
+        VmSize?: AzureVmSize,
+        /** The configuration for the VmStartupScript feature for the build */
+        VmStartupScriptConfiguration?: VmStartupScriptConfiguration,
+    }
+
+    /** Request to create a lobby. A Server or client can create a lobby. */
+    interface CreateLobbyRequest {
+        /**
+         * The policy indicating who is allowed to join the lobby, and the visibility to queries. May be 'Public', 'Friends' or
+         * 'Private'. Public means the lobby is both visible in queries and any player may join, including invited players. Friends
+         * means that users who are bidirectional friends of members in the lobby may search to find friend lobbies, to retrieve
+         * its connection string. Private means the lobby is not visible in queries, and a player must receive an invitation to
+         * join. Defaults to 'Public' on creation. Can only be changed by the lobby owner.
+         */
+        AccessPolicy?: AccessPolicy,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /**
+         * The private key-value pairs which are visible to all entities in the lobby. At most 30 key-value pairs may be stored
+         * here, keys are limited to 30 characters and values to 1000. The total size of all lobbyData values may not exceed 4096
+         * bytes. Keys are case sensitive.
+         */
+        LobbyData?: { [key: string]: string | null },
+        /** The maximum number of players allowed in the lobby. The value must be between 2 and 128. */
+        MaxPlayers: number,
+        /**
+         * The member initially added to the lobby. Client must specify exactly one member, which is the creator's entity and
+         * member data. Member PubSubConnectionHandle must be null or empty. Game servers must not specify any members.
+         */
+        Members?: Member[],
+        /** The lobby owner. Must be the calling entity. */
+        Owner: EntityKey,
+        /**
+         * The policy for how a new owner is chosen. May be 'Automatic', 'Manual' or 'None'. Can only be specified by clients. If
+         * client-owned and 'Automatic' - The Lobby service will automatically assign another connected owner when the current
+         * owner leaves or disconnects. The useConnections property must be true. If client - owned and 'Manual' - Ownership is
+         * protected as long as the current owner is connected. If the current owner leaves or disconnects any member may set
+         * themselves as the current owner. The useConnections property must be true. If client-owned and 'None' - Any member can
+         * set ownership. The useConnections property can be either true or false.
+         */
+        OwnerMigrationPolicy?: OwnerMigrationPolicy,
+        /**
+         * A setting that controls whether only the lobby owner can send invites to join the lobby. When true, only the lobby owner
+         * can send invites. When false or not specified, any member can send invites. Defaults to false if not specified.
+         * Restricted to client owned lobbies.
+         */
+        RestrictInvitesToLobbyOwner: boolean,
+        /**
+         * The public key-value pairs which allow queries to differentiate between lobbies. Queries will refer to these key-value
+         * pairs in their filter and order by clauses to retrieve lobbies fitting the specified criteria. At most 30 key-value
+         * pairs may be stored here. Keys are of the format string_key1, string_key2 ... string_key30 for string values, or
+         * number_key1, number_key2, ... number_key30 for numeric values.Numeric values are floats. Values can be at most 256
+         * characters long. The total size of all searchData values may not exceed 1024 bytes.
+         */
+        SearchData?: { [key: string]: string | null },
+        /**
+         * A setting to control whether connections are used. Defaults to true. When true, notifications are sent to subscribed
+         * players, disconnect detection removes connectionHandles, only owner migration policies using connections are allowed,
+         * and lobbies must have at least one connected member to be searchable or be a server hosted lobby with a connected
+         * server. If false, then notifications are not sent, connections are not allowed, and lobbies do not need connections to
+         * be searchable.
+         */
+        UseConnections: boolean,
+    }
+
+    interface CreateLobbyResult {
+        /** A field which indicates which lobby the user will be joining. */
+        ConnectionString: string,
+        /** Id to uniquely identify a lobby. */
+        LobbyId: string,
+    }
+
+    /** The client specifies the creator's attributes and optionally a list of other users to match with. */
+    interface CreateMatchmakingTicketRequest {
+        /** The User who created this ticket. */
+        Creator: MatchmakingPlayer,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** How long to attempt matching this ticket in seconds. */
+        GiveUpAfterSeconds: number,
+        /** A list of Entity Keys of other users to match with. */
+        MembersToMatchWith?: EntityKey[],
+        /** The Id of a match queue. */
+        QueueName: string,
+    }
+
+    interface CreateMatchmakingTicketResult {
+        /** The Id of the ticket to find a match for. */
+        TicketId: string,
+    }
+
+    /**
+     * Creates a remote user to log on to a VM for a multiplayer server build in a specific region. Returns user credential
+     * information necessary to log on.
+     */
+    interface CreateRemoteUserRequest {
+        /** The guid string build ID of to create the remote user for. */
+        BuildId: string,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The expiration time for the remote user created. Defaults to expiring in one day if not specified. */
+        ExpirationTime?: string,
+        /** The region of virtual machine to create the remote user for. */
+        Region: string,
+        /** The username to create the remote user with. */
+        Username: string,
+        /** The virtual machine ID the multiplayer server is located on. */
+        VmId: string,
+    }
+
+    interface CreateRemoteUserResponse {
+        /** The expiration time for the remote user created. */
+        ExpirationTime?: string,
+        /** The generated password for the remote user that was created. */
+        Password?: string,
+        /** The username for the remote user that was created. */
+        Username?: string,
+    }
+
+    /** The server specifies all the members, their teams and their attributes, and the server details if applicable. */
+    interface CreateServerBackfillTicketRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** How long to attempt matching this ticket in seconds. */
+        GiveUpAfterSeconds: number,
+        /** The users who will be part of this ticket, along with their team assignments. */
+        Members: MatchmakingPlayerWithTeamAssignment[],
+        /** The Id of a match queue. */
+        QueueName: string,
+        /** The details of the server the members are connected to. */
+        ServerDetails?: ServerDetails,
+    }
+
+    interface CreateServerBackfillTicketResult {
+        /** The Id of the ticket to find a match for. */
+        TicketId: string,
+    }
+
+    /** The server specifies all the members and their attributes. */
+    interface CreateServerMatchmakingTicketRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** How long to attempt matching this ticket in seconds. */
+        GiveUpAfterSeconds: number,
+        /** The users who will be part of this ticket. */
+        Members: MatchmakingPlayer[],
+        /** The Id of a match queue. */
+        QueueName: string,
+    }
+
+    /** Creates a request to change a title's multiplayer server quotas. */
+    interface CreateTitleMultiplayerServersQuotaChangeRequest {
+        /** A brief description of the requested changes. */
+        ChangeDescription?: string,
+        /** Changes to make to the titles cores quota. */
+        Changes: CoreCapacityChange[],
+        /** Email to be contacted by our team about this request. Only required when a request is not approved. */
+        ContactEmail?: string,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** Additional information about this request that our team can use to better understand the requirements. */
+        Notes?: string,
+        /** When these changes would need to be in effect. Only required when a request is not approved. */
+        StartDate?: string,
+    }
+
+    interface CreateTitleMultiplayerServersQuotaChangeResponse {
+        /** Id of the change request that was created. */
+        RequestId?: string,
+        /** Determines if the request was approved or not. When false, our team is reviewing and may respond within 2 business days. */
+        WasApproved: boolean,
+    }
+
+    interface CurrentServerStats {
+        /** The number of active multiplayer servers. */
+        Active: number,
+        /** The number of multiplayer servers still downloading game resources (such as assets). */
+        Propping: number,
+        /** The number of standingby multiplayer servers. */
+        StandingBy: number,
+        /** The total number of multiplayer servers. */
+        Total: number,
+    }
+
+    interface CustomDifferenceRuleExpansion {
+        /** Manually specify the values to use for each expansion interval (this overrides Difference, Delta, and MaxDifference). */
+        DifferenceOverrides: OverrideDouble[],
+        /** How many seconds before this rule is expanded. */
+        SecondsBetweenExpansions: number,
+    }
+
+    interface CustomRegionSelectionRuleExpansion {
+        /** Manually specify the maximum latency to use for each expansion interval. */
+        MaxLatencyOverrides: OverrideUnsignedInt[],
+        /** How many seconds before this rule is expanded. */
+        SecondsBetweenExpansions: number,
+    }
+
+    interface CustomSetIntersectionRuleExpansion {
+        /** Manually specify the values to use for each expansion interval. */
+        MinIntersectionSizeOverrides: OverrideUnsignedInt[],
+        /** How many seconds before this rule is expanded. */
+        SecondsBetweenExpansions: number,
+    }
+
+    interface CustomTeamDifferenceRuleExpansion {
+        /** Manually specify the team difference value to use for each expansion interval. */
+        DifferenceOverrides: OverrideDouble[],
+        /** How many seconds before this rule is expanded. */
+        SecondsBetweenExpansions: number,
+    }
+
+    interface CustomTeamSizeBalanceRuleExpansion {
+        /** Manually specify the team size difference to use for each expansion interval. */
+        DifferenceOverrides: OverrideUnsignedInt[],
+        /** How many seconds before this rule is expanded. */
+        SecondsBetweenExpansions: number,
+    }
+
+    /** Deletes a multiplayer server game asset for a title. */
+    interface DeleteAssetRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The filename of the asset to delete. */
+        FileName: string,
+    }
+
+    /** Deletes a multiplayer server build alias. */
+    interface DeleteBuildAliasRequest {
+        /** The guid string alias ID of the alias to perform the action on. */
+        AliasId: string,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+    }
+
+    /** Removes a multiplayer server build's region. */
+    interface DeleteBuildRegionRequest {
+        /** The guid string ID of the build we want to update regions for. */
+        BuildId: string,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The build region to delete. */
+        Region: string,
+    }
+
+    /** Deletes a multiplayer server build. */
+    interface DeleteBuildRequest {
+        /** The guid string build ID of the build to delete. */
+        BuildId: string,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+    }
+
+    /** Deletes a multiplayer server game certificate. */
+    interface DeleteCertificateRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The name of the certificate. */
+        Name: string,
+    }
+
+    /**
+     * Removes the specified container image repository. After this operation, a 'docker pull' will fail for all the tags of
+     * the specified image. Morever, ListContainerImages will not return the specified image.
+     */
+    interface DeleteContainerImageRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The container image repository we want to delete. */
+        ImageName?: string,
+    }
+
+    /** Request to delete a lobby. Only servers can delete lobbies. */
+    interface DeleteLobbyRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The id of the lobby. */
+        LobbyId?: string,
+    }
+
+    /**
+     * Deletes a remote user to log on to a VM for a multiplayer server build in a specific region. Returns user credential
+     * information necessary to log on.
+     */
+    interface DeleteRemoteUserRequest {
+        /** The guid string build ID of the multiplayer server where the remote user is to delete. */
+        BuildId: string,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The region of the multiplayer server where the remote user is to delete. */
+        Region: string,
+        /** The username of the remote user to delete. */
+        Username: string,
+        /** The virtual machine ID the multiplayer server is located on. */
+        VmId: string,
+    }
+
+    /** Deletes a multiplayer server game secret. */
+    interface DeleteSecretRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The name of the secret. */
+        Name: string,
+    }
+
+    interface DifferenceRule {
+        /** Description of the attribute used by this rule to match tickets. */
+        Attribute: QueueRuleAttribute,
+        /**
+         * Describes the behavior when an attribute is not specified in the ticket creation request or in the user's entity
+         * profile.
+         */
+        AttributeNotSpecifiedBehavior: AttributeNotSpecifiedBehavior,
+        /**
+         * Collection of fields relating to expanding this rule at set intervals. Only one expansion can be set per rule. When this
+         * is set, Difference is ignored.
+         */
+        CustomExpansion?: CustomDifferenceRuleExpansion,
+        /**
+         * The default value assigned to tickets that are missing the attribute specified by AttributePath (assuming that
+         * AttributeNotSpecifiedBehavior is false). Optional.
+         */
+        DefaultAttributeValue?: number,
+        /** The allowed difference between any two tickets at the start of matchmaking. */
+        Difference: number,
+        /** Collection of fields relating to expanding this rule at set intervals. Only one expansion can be set per rule. */
+        LinearExpansion?: LinearDifferenceRuleExpansion,
+        /** How values are treated when there are multiple players in a single ticket. */
+        MergeFunction: AttributeMergeFunction,
+        /** Friendly name chosen by developer. */
+        Name: string,
+        /**
+         * How many seconds before this rule is no longer enforced (but tickets that comply with this rule will still be
+         * prioritized over those that don't). Leave blank if this rule is always enforced.
+         */
+        SecondsUntilOptional?: number,
+        /** The relative weight of this rule compared to others. */
+        Weight: number,
+    }
+
+    type DirectPeerConnectivityOptions = "None"
+
+        | "SamePlatformType"
+        | "DifferentPlatformType"
+        | "AnyPlatformType"
+        | "SameEntityLoginProvider"
+        | "DifferentEntityLoginProvider"
+        | "AnyEntityLoginProvider"
+        | "AnyPlatformTypeAndEntityLoginProvider"
+        | "OnlyServers";
+
+    interface DynamicStandbySettings {
+        /**
+         * List of auto standing by trigger values and corresponding standing by multiplier. Defaults to 1.5X at 50%, 3X at 25%,
+         * and 4X at 5%
+         */
+        DynamicFloorMultiplierThresholds?: DynamicStandbyThreshold[],
+        /** When true, dynamic standby will be enabled */
+        IsEnabled: boolean,
+        /** The time it takes to reduce target standing by to configured floor value after an increase. Defaults to 30 minutes */
+        RampDownSeconds?: number,
+    }
+
+    interface DynamicStandbyThreshold {
+        /** When the trigger threshold is reached, multiply by this value */
+        Multiplier: number,
+        /** The multiplier will be applied when the actual standby divided by target standby floor is less than this value */
+        TriggerThresholdPercentage: number,
+    }
+
+    interface EmptyResponse {
+    }
+
+    /**
+     * Enables the multiplayer server feature for a title and returns the enabled status. The enabled status can be
+     * Initializing, Enabled, and Disabled. It can up to 20 minutes or more for the title to be enabled for the feature. On
+     * average, it can take up to 20 minutes for the title to be enabled for the feature.
+     */
+    interface EnableMultiplayerServersForTitleRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+    }
+
+    interface EnableMultiplayerServersForTitleResponse {
+        /** The enabled status for the multiplayer server features for the title. */
+        Status?: TitleMultiplayerServerEnabledStatus,
+    }
+
+    /** Combined entity type and ID structure which uniquely identifies a single entity. */
+    interface EntityKey {
+        /** Unique ID of the entity. */
+        Id: string,
+        /** Entity type. See https://docs.microsoft.com/gaming/playfab/features/data/entities/available-built-in-entity-types */
+        Type?: string,
+    }
+
+    type ExternalFriendSources = "None"
+
+        | "Steam"
+        | "Facebook"
+        | "Xbox"
+        | "Psn"
+        | "All";
+
+    /** Request to find friends lobbies. Only a client can find friend lobbies. */
+    interface FindFriendLobbiesRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** Indicates which other platforms' friends this query should link to. */
+        ExternalPlatformFriends?: ExternalFriendSources,
+        /**
+         * OData style string that contains one or more filters. Only the following operators are supported: "and" (logical and),
+         * "eq" (equal), "ne" (not equals), "ge" (greater than or equal), "gt" (greater than), "le" (less than or equal), and "lt"
+         * (less than). The left-hand side of each OData logical expression should be either a search property key (e.g.
+         * string_key1, number_key3, etc) or one of the pre-defined search keys all of which must be prefixed by "lobby/":
+         * lobby/memberCount (number of players in a lobby), lobby/maxMemberCount (maximum number of players allowed in a lobby),
+         * lobby/memberCountRemaining (remaining number of players who can be allowed in a lobby), lobby/membershipLock (must equal
+         * 'Unlocked' or 'Locked'), lobby/amOwner (required to equal "true"), lobby/amMember (required to equal "true").
+         */
+        Filter?: string,
+        /**
+         * OData style string that contains sorting for this query in either ascending ("asc") or descending ("desc") order.
+         * OrderBy clauses are of the form "number_key1 asc" or the pre-defined search key "lobby/memberCount asc",
+         * "lobby/memberCountRemaining desc" and "lobby/maxMemberCount desc". To sort by closest, a moniker `distance{number_key1 =
+         * 5}` can be used to sort by distance from the given number. This field only supports either one sort clause or one
+         * distance clause.
+         */
+        OrderBy?: string,
+        /** Request pagination information. */
+        Pagination?: PaginationRequest,
+        /** Xbox token if Xbox friends should be included. Requires Xbox be configured on PlayFab. */
+        XboxToken?: string,
+    }
+
+    interface FindFriendLobbiesResult {
+        /** Array of lobbies found that matched FindFriendLobbies request. */
+        Lobbies: FriendLobbySummary[],
+        /** Pagination response for FindFriendLobbies request. */
+        Pagination: PaginationResponse,
+    }
+
+    /** Request to find lobbies. */
+    interface FindLobbiesRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /**
+         * OData style string that contains one or more filters. Only the following operators are supported: "and" (logical and),
+         * "eq" (equal), "ne" (not equals), "ge" (greater than or equal), "gt" (greater than), "le" (less than or equal), and "lt"
+         * (less than). The left-hand side of each OData logical expression should be either a search property key (e.g.
+         * string_key1, number_key3, etc) or one of the pre-defined search keys all of which must be prefixed by "lobby/":
+         * lobby/memberCount (number of players in a lobby), lobby/maxMemberCount (maximum number of players allowed in a lobby),
+         * lobby/memberCountRemaining (remaining number of players who can be allowed in a lobby), lobby/membershipLock (must equal
+         * 'Unlocked' or 'Locked'), lobby/amOwner (required to equal "true"), lobby/amMember (required to equal "true").
+         */
+        Filter?: string,
+        /**
+         * OData style string that contains sorting for this query in either ascending ("asc") or descending ("desc") order.
+         * OrderBy clauses are of the form "number_key1 asc" or the pre-defined search key "lobby/memberCount asc",
+         * "lobby/memberCountRemaining desc" and "lobby/maxMemberCount desc". To sort by closest, a moniker `distance{number_key1 =
+         * 5}` can be used to sort by distance from the given number. This field only supports either one sort clause or one
+         * distance clause.
+         */
+        OrderBy?: string,
+        /** Request pagination information. */
+        Pagination?: PaginationRequest,
+    }
+
+    interface FindLobbiesResult {
+        /** Array of lobbies found that matched FindLobbies request. */
+        Lobbies: LobbySummary[],
+        /** Pagination response for FindLobbies request. */
+        Pagination: PaginationResponse,
+    }
+
+    interface FriendLobbySummary {
+        /**
+         * A string used to join the lobby.This field is populated by the Lobby service.Invites are performed by communicating this
+         * connectionString to other players.
+         */
+        ConnectionString: string,
+        /** The current number of players in the lobby. */
+        CurrentPlayers: number,
+        /** Friends in Lobby. */
+        Friends?: EntityKey[],
+        /** Id to uniquely identify a lobby. */
+        LobbyId: string,
+        /** The maximum number of players allowed in the lobby. */
+        MaxPlayers: number,
+        /** A setting indicating whether members are allowed to join this lobby. When Locked new members are prevented from joining. */
+        MembershipLock?: MembershipLock,
+        /** The client or server entity which owns this lobby. */
+        Owner: EntityKey,
+        /** Search data. */
+        SearchData?: { [key: string]: string | null },
+    }
+
+    interface GameCertificateReference {
+        /**
+         * An alias for the game certificate. The game server will reference this alias via GSDK config to retrieve the game
+         * certificate. This alias is used as an identifier in game server code to allow a new certificate with different Name
+         * field to be uploaded without the need to change any game server code to reference the new Name.
+         */
+        GsdkAlias?: string,
+        /**
+         * The name of the game certificate. This name should match the name of a certificate that was previously uploaded to this
+         * title.
+         */
+        Name?: string,
+    }
+
+    interface GameCertificateReferenceParams {
+        /**
+         * An alias for the game certificate. The game server will reference this alias via GSDK config to retrieve the game
+         * certificate. This alias is used as an identifier in game server code to allow a new certificate with different Name
+         * field to be uploaded without the need to change any game server code to reference the new Name.
+         */
+        GsdkAlias: string,
+        /**
+         * The name of the game certificate. This name should match the name of a certificate that was previously uploaded to this
+         * title.
+         */
+        Name: string,
+    }
+
+    interface GameSecretReference {
+        /** The name of the game secret. This name should match the name of a secret that was previously added to this title. */
+        Name?: string,
+    }
+
+    interface GameSecretReferenceParams {
+        /** The name of the game secret. This name should match the name of a secret that was previously added to this title. */
+        Name: string,
+    }
+
+    /** Gets a URL that can be used to download the specified asset. */
+    interface GetAssetDownloadUrlRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The asset's file name to get the download URL for. */
+        FileName: string,
+    }
+
+    interface GetAssetDownloadUrlResponse {
+        /** The asset's download URL. */
+        AssetDownloadUrl?: string,
+        /** The asset's file name to get the download URL for. */
+        FileName?: string,
+    }
+
+    /** Gets the URL to upload assets to. */
+    interface GetAssetUploadUrlRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The asset's file name to get the upload URL for. */
+        FileName: string,
+    }
+
+    interface GetAssetUploadUrlResponse {
+        /** The asset's upload URL. */
+        AssetUploadUrl?: string,
+        /** The asset's file name to get the upload URL for. */
+        FileName?: string,
+    }
+
+    /** Returns the details about a multiplayer server build alias. */
+    interface GetBuildAliasRequest {
+        /** The guid string alias ID of the alias to perform the action on. */
+        AliasId: string,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+    }
+
+    /** Returns the details about a multiplayer server build. */
+    interface GetBuildRequest {
+        /** The guid string build ID of the build to get. */
+        BuildId: string,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+    }
+
+    interface GetBuildResponse {
+        /**
+         * When true, assets will not be copied for each server inside the VM. All serverswill run from the same set of assets, or
+         * will have the same assets mounted in the container.
+         */
+        AreAssetsReadonly?: boolean,
+        /** The guid string build ID of the build. */
+        BuildId?: string,
+        /** The build name. */
+        BuildName?: string,
+        /** The current build status. Valid values are - Deploying, Deployed, DeletingRegion, Unhealthy. */
+        BuildStatus?: string,
+        /** The flavor of container of he build. */
+        ContainerFlavor?: ContainerFlavor,
+        /**
+         * The container command to run when the multiplayer server has been allocated, including any arguments. This only applies
+         * to custom builds. If the build is a managed build, this field will be null.
+         */
+        ContainerRunCommand?: string,
+        /** The time the build was created in UTC. */
+        CreationTime?: string,
+        /** The custom game container image for a custom build. */
+        CustomGameContainerImage?: ContainerImageReference,
+        /** The game assets for the build. */
+        GameAssetReferences?: AssetReference[],
+        /** The game certificates for the build. */
+        GameCertificateReferences?: GameCertificateReference[],
+        /** The instrumentation configuration of the build. */
+        InstrumentationConfiguration?: InstrumentationConfiguration,
+        /**
+         * Metadata of the build. The keys are case insensitive. The build metadata is made available to the server through Game
+         * Server SDK (GSDK).
+         */
+        Metadata?: { [key: string]: string | null },
+        /** The number of multiplayer servers to hosted on a single VM of the build. */
+        MultiplayerServerCountPerVm: number,
+        /** The OS platform used for running the game process. */
+        OsPlatform?: string,
+        /** The ports the build is mapped on. */
+        Ports?: Port[],
+        /** The region configuration for the build. */
+        RegionConfigurations?: BuildRegion[],
+        /** The resource constraints to apply to each server on the VM. */
+        ServerResourceConstraints?: ServerResourceConstraintParams,
+        /** The type of game server being hosted. */
+        ServerType?: string,
+        /**
+         * The command to run when the multiplayer server has been allocated, including any arguments. This only applies to managed
+         * builds. If the build is a custom build, this field will be null.
+         */
+        StartMultiplayerServerCommand?: string,
+        /** The VM size the build was created on. */
+        VmSize?: AzureVmSize,
+        /** The configuration for the VmStartupScript feature for the build */
+        VmStartupScriptConfiguration?: VmStartupScriptConfiguration,
+    }
+
+    /**
+     * Gets credentials to the container registry where game developers can upload custom container images to before creating a
+     * new build.
+     */
+    interface GetContainerRegistryCredentialsRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+    }
+
+    interface GetContainerRegistryCredentialsResponse {
+        /** The url of the container registry. */
+        DnsName?: string,
+        /** The password for accessing the container registry. */
+        Password?: string,
+        /** The username for accessing the container registry. */
+        Username?: string,
+    }
+
+    /** Request to get a lobby. */
+    interface GetLobbyRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The id of the lobby. */
+        LobbyId?: string,
+    }
+
+    interface GetLobbyResult {
+        /** The information pertaining to the requested lobby. */
+        Lobby: Lobby,
+    }
+
+    /** Gets the current configuration for a queue. */
+    interface GetMatchmakingQueueRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The Id of the matchmaking queue to retrieve. */
+        QueueName?: string,
+    }
+
+    interface GetMatchmakingQueueResult {
+        /** The matchmaking queue config. */
+        MatchmakingQueue?: MatchmakingQueueConfig,
+    }
+
+    /**
+     * The ticket includes the invited players, their attributes if they have joined, the ticket status, the match Id when
+     * applicable, etc. Only servers, the ticket creator and the invited players can get the ticket.
+     */
+    interface GetMatchmakingTicketRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /**
+         * Determines whether the matchmaking attributes will be returned as an escaped JSON string or as an un-escaped JSON
+         * object.
+         */
+        EscapeObject: boolean,
+        /** The name of the queue to find a match for. */
+        QueueName: string,
+        /** The Id of the ticket to find a match for. */
+        TicketId: string,
+    }
+
+    interface GetMatchmakingTicketResult {
+        /**
+         * The reason why the current ticket was canceled. This field is only set if the ticket is in canceled state. Please retry
+         * if CancellationReason is RetryRequired.
+         */
+        CancellationReasonString?: string,
+        /** Change number used for differentiating older matchmaking status updates from newer ones. */
+        ChangeNumber?: number,
+        /** The server date and time at which ticket was created. */
+        Created: string,
+        /** The Creator's entity key. */
+        Creator: EntityKey,
+        /** How long to attempt matching this ticket in seconds. */
+        GiveUpAfterSeconds: number,
+        /** The Id of a match. */
+        MatchId?: string,
+        /** A list of Users that have joined this ticket. */
+        Members: MatchmakingPlayer[],
+        /** A list of PlayFab Ids of Users to match with. */
+        MembersToMatchWith?: EntityKey[],
+        /** The Id of a match queue. */
+        QueueName: string,
+        /**
+         * The current ticket status. Possible values are: WaitingForPlayers, WaitingForMatch, WaitingForServer, Canceled and
+         * Matched.
+         */
+        Status: string,
+        /** The Id of the ticket to find a match for. */
+        TicketId: string,
+    }
+
+    /**
+     * When matchmaking has successfully matched together a collection of tickets, it produces a 'match' with an Id. The match
+     * contains all of the players that were matched together, and their team assigments. Only servers and ticket members can
+     * get the match.
+     */
+    interface GetMatchRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /**
+         * Determines whether the matchmaking attributes will be returned as an escaped JSON string or as an un-escaped JSON
+         * object.
+         */
+        EscapeObject: boolean,
+        /** The Id of a match. */
+        MatchId: string,
+        /** The name of the queue to join. */
+        QueueName: string,
+        /** Determines whether the matchmaking attributes for each user should be returned in the response for match request. */
+        ReturnMemberAttributes: boolean,
+    }
+
+    interface GetMatchResult {
+        /** A string that is used by players that are matched together to join an arranged lobby. */
+        ArrangementString?: string,
+        /** The Id of a match. */
+        MatchId: string,
+        /** A list of Users that are matched together, along with their team assignments. */
+        Members: MatchmakingPlayerWithTeamAssignment[],
+        /**
+         * A list of regions that the match could be played in sorted by preference. This value is only set if the queue has a
+         * region selection rule.
+         */
+        RegionPreferences?: string[],
+        /** The details of the server that the match has been allocated to. */
+        ServerDetails?: ServerDetails,
+    }
+
+    /** Gets multiplayer server session details for a build in a specific region. */
+    interface GetMultiplayerServerDetailsRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /**
+         * The title generated guid string session ID of the multiplayer server to get details for. This is to keep track of
+         * multiplayer server sessions.
+         */
+        SessionId: string,
+    }
+
+    interface GetMultiplayerServerDetailsResponse {
+        /** The identity of the build in which the server was allocated. */
+        BuildId?: string,
+        /** The connected players in the multiplayer server. */
+        ConnectedPlayers?: ConnectedPlayer[],
+        /** The fully qualified domain name of the virtual machine that is hosting this multiplayer server. */
+        FQDN?: string,
+        /** The public IPv4 address of the virtual machine that is hosting this multiplayer server. */
+        IPV4Address?: string,
+        /** The time (UTC) at which a change in the multiplayer server state was observed. */
+        LastStateTransitionTime?: string,
+        /** The ports the multiplayer server uses. */
+        Ports?: Port[],
+        /** The list of public Ipv4 addresses associated with the server. */
+        PublicIPV4Addresses?: PublicIpAddress[],
+        /** The region the multiplayer server is located in. */
+        Region?: string,
+        /** The string server ID of the multiplayer server generated by PlayFab. */
+        ServerId?: string,
+        /** The guid string session ID of the multiplayer server. */
+        SessionId?: string,
+        /** The state of the multiplayer server. */
+        State?: string,
+        /** The virtual machine ID that the multiplayer server is located on. */
+        VmId?: string,
+    }
+
+    /**
+     * Gets multiplayer server logs for a specific server id in a region. The logs are available only after a server has
+     * terminated.
+     */
+    interface GetMultiplayerServerLogsRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The server ID of multiplayer server to get logs for. */
+        ServerId: string,
+    }
+
+    interface GetMultiplayerServerLogsResponse {
+        /** URL for logs download. */
+        LogDownloadUrl?: string,
+    }
+
+    /**
+     * Gets multiplayer server logs for a specific server id in a region. The logs are available only after a server has
+     * terminated.
+     */
+    interface GetMultiplayerSessionLogsBySessionIdRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The server ID of multiplayer server to get logs for. */
+        SessionId: string,
+    }
+
+    /**
+     * Returns the matchmaking statistics for a queue. These include the number of players matching and the statistics related
+     * to the time to match statistics in seconds (average and percentiles). Statistics are refreshed once every 5 minutes.
+     * Servers can access all statistics no matter what the ClientStatisticsVisibility is configured to. Clients can access
+     * statistics according to the ClientStatisticsVisibility. Client requests are forbidden if all visibility fields are
+     * false.
+     */
+    interface GetQueueStatisticsRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The name of the queue. */
+        QueueName: string,
+    }
+
+    interface GetQueueStatisticsResult {
+        /** The current number of players in the matchmaking queue, who are waiting to be matched. */
+        NumberOfPlayersMatching?: number,
+        /** Statistics representing the time (in seconds) it takes for tickets to find a match. */
+        TimeToMatchStatisticsInSeconds?: Statistics,
+    }
+
+    /** Gets a remote login endpoint to a VM that is hosting a multiplayer server build in a specific region. */
+    interface GetRemoteLoginEndpointRequest {
+        /** The guid string build ID of the multiplayer server to get remote login information for. */
+        BuildId: string,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The region of the multiplayer server to get remote login information for. */
+        Region: string,
+        /** The virtual machine ID the multiplayer server is located on. */
+        VmId: string,
+    }
+
+    interface GetRemoteLoginEndpointResponse {
+        /** The remote login IPV4 address of multiplayer server. */
+        IPV4Address?: string,
+        /** The remote login port of multiplayer server. */
+        Port: number,
+    }
+
+    /**
+     * The ticket includes the players, their attributes, their teams, the ticket status, the match Id and the server details
+     * when applicable, etc. Only servers can get the ticket.
+     */
+    interface GetServerBackfillTicketRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /**
+         * Determines whether the matchmaking attributes will be returned as an escaped JSON string or as an un-escaped JSON
+         * object.
+         */
+        EscapeObject: boolean,
+        /** The name of the queue to find a match for. */
+        QueueName: string,
+        /** The Id of the ticket to find a match for. */
+        TicketId: string,
+    }
+
+    interface GetServerBackfillTicketResult {
+        /** The reason why the current ticket was canceled. This field is only set if the ticket is in canceled state. */
+        CancellationReasonString?: string,
+        /** The server date and time at which ticket was created. */
+        Created: string,
+        /** How long to attempt matching this ticket in seconds. */
+        GiveUpAfterSeconds: number,
+        /** The Id of a match. */
+        MatchId?: string,
+        /** A list of Users that are part of this ticket, along with their team assignments. */
+        Members: MatchmakingPlayerWithTeamAssignment[],
+        /** The Id of a match queue. */
+        QueueName: string,
+        /** The details of the server the members are connected to. */
+        ServerDetails: ServerDetails,
+        /** The current ticket status. Possible values are: WaitingForMatch, Canceled and Matched. */
+        Status: string,
+        /** The Id of the ticket to find a match for. */
+        TicketId: string,
+    }
+
+    /**
+     * Gets the status of whether a title is enabled for the multiplayer server feature. The enabled status can be
+     * Initializing, Enabled, and Disabled.
+     */
+    interface GetTitleEnabledForMultiplayerServersStatusRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+    }
+
+    interface GetTitleEnabledForMultiplayerServersStatusResponse {
+        /** The enabled status for the multiplayer server features for the title. */
+        Status?: TitleMultiplayerServerEnabledStatus,
+    }
+
+    /** Gets a title's server quota change request. */
+    interface GetTitleMultiplayerServersQuotaChangeRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** Id of the change request to get. */
+        RequestId: string,
+    }
+
+    interface GetTitleMultiplayerServersQuotaChangeResponse {
+        /** The change request for this title. */
+        Change?: QuotaChange,
+    }
+
+    /** Gets the quotas for a title in relation to multiplayer servers. */
+    interface GetTitleMultiplayerServersQuotasRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+    }
+
+    interface GetTitleMultiplayerServersQuotasResponse {
+        /** The various quotas for multiplayer servers for the title. */
+        Quotas?: TitleMultiplayerServersQuotas,
+    }
+
+    interface InstrumentationConfiguration {
+        /** Designates whether windows instrumentation configuration will be enabled for this Build */
+        IsEnabled?: boolean,
+        /**
+         * This property is deprecated, use IsEnabled. The list of processes to be monitored on a VM for this build. Providing
+         * processes will turn on performance metrics collection for this build. Process names should not include extensions. If
+         * the game server process is: GameServer.exe; then, ProcessesToMonitor = [ GameServer ]
+         */
+        ProcessesToMonitor?: string[],
+    }
+
+    /**
+     * Request to invite a player to a lobby the caller is already a member of. Only a client can invite another player to a
+     * lobby.
+     */
+    interface InviteToLobbyRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The entity invited to the lobby. */
+        InviteeEntity?: EntityKey,
+        /** The id of the lobby. */
+        LobbyId?: string,
+        /** The member entity sending the invite. Must be a member of the lobby. */
+        MemberEntity?: EntityKey,
+    }
+
+    /** Request to join an arranged lobby. Only a client can join an arranged lobby. */
+    interface JoinArrangedLobbyRequest {
+        /**
+         * The policy indicating who is allowed to join the lobby, and the visibility to queries. May be 'Public', 'Friends' or
+         * 'Private'. Public means the lobby is both visible in queries and any player may join, including invited players. Friends
+         * means that users who are bidirectional friends of members in the lobby may search to find friend lobbies, to retrieve
+         * its connection string. Private means the lobby is not visible in queries, and a player must receive an invitation to
+         * join. Defaults to 'Public' on creation. Can only be changed by the lobby owner.
+         */
+        AccessPolicy?: AccessPolicy,
+        /**
+         * A field which indicates which lobby the user will be joining. This field is opaque to everyone except the Lobby service
+         * and the creator of the arrangementString (Matchmaking). This string defines a unique identifier for the arranged lobby
+         * as well as the title and member the string is valid for. Arrangement strings have an expiration.
+         */
+        ArrangementString: string,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The maximum number of players allowed in the lobby. The value must be between 2 and 128. */
+        MaxPlayers: number,
+        /**
+         * The private key-value pairs used by the member to communicate information to other members and the owner. Visible to all
+         * entities in the lobby. At most 30 key-value pairs may be stored here, keys are limited to 30 characters and values to
+         * 1000. The total size of all memberData values may not exceed 4096 bytes. Keys are case sensitive.
+         */
+        MemberData?: { [key: string]: string | null },
+        /** The member entity who is joining the lobby. The first member to join will be the lobby owner. */
+        MemberEntity: EntityKey,
+        /**
+         * The policy for how a new owner is chosen. May be 'Automatic', 'Manual' or 'None'. Can only be specified by clients. If
+         * client-owned and 'Automatic' - The Lobby service will automatically assign another connected owner when the current
+         * owner leaves or disconnects. The useConnections property must be true. If client - owned and 'Manual' - Ownership is
+         * protected as long as the current owner is connected. If the current owner leaves or disconnects any member may set
+         * themselves as the current owner. The useConnections property must be true. If client-owned and 'None' - Any member can
+         * set ownership. The useConnections property can be either true or false.
+         */
+        OwnerMigrationPolicy?: OwnerMigrationPolicy,
+        /**
+         * A setting that controls whether only the lobby owner can send invites to join the lobby. When true, only the lobby owner
+         * can send invites. When false or not specified, any member can send invites. Defaults to false if not specified.
+         * Restricted to client owned lobbies.
+         */
+        RestrictInvitesToLobbyOwner: boolean,
+        /**
+         * A setting to control whether connections are used. Defaults to true. When true, notifications are sent to subscribed
+         * players, disconnect detection removes connectionHandles, only owner migration policies using connections are allowed,
+         * and lobbies must have at least one connected member to be searchable or be a server hosted lobby with a connected
+         * server. If false, then notifications are not sent, connections are not allowed, and lobbies do not need connections to
+         * be searchable.
+         */
+        UseConnections: boolean,
+    }
+
+    /**
+     * Preview: Request to join a lobby as a server. Only callable by a game_server entity and this is restricted to client
+     * owned lobbies which are using connections.
+     */
+    interface JoinLobbyAsServerRequest {
+        /**
+         * A field which indicates which lobby the game_server will be joining. This field is opaque to everyone except the Lobby
+         * service.
+         */
+        ConnectionString: string,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /**
+         * The private key-value pairs which are visible to all entities in the lobby but can only be modified by the joined
+         * server.At most 30 key - value pairs may be stored here, keys are limited to 30 characters and values to 1000.The total
+         * size of all serverData values may not exceed 4096 bytes.
+         */
+        ServerData?: { [key: string]: string | null },
+        /**
+         * The game_server entity which is joining the Lobby. If a different game_server entity has already joined the request will
+         * fail unless the joined entity is disconnected, in which case the incoming game_server entity will replace the
+         * disconnected entity.
+         */
+        ServerEntity: EntityKey,
+    }
+
+    interface JoinLobbyAsServerResult {
+        /** Successfully joined lobby's id. */
+        LobbyId: string,
+    }
+
+    /** Request to join a lobby. Only a client can join a lobby. */
+    interface JoinLobbyRequest {
+        /** A field which indicates which lobby the user will be joining. This field is opaque to everyone except the Lobby service. */
+        ConnectionString?: string,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /**
+         * The private key-value pairs used by the member to communicate information to other members and the owner. Visible to all
+         * entities in the lobby. At most 30 key-value pairs may be stored here, keys are limited to 30 characters and values to
+         * 1000. The total size of all memberData values may not exceed 4096 bytes.Keys are case sensitive.
+         */
+        MemberData?: { [key: string]: string | null },
+        /** The member entity who is joining the lobby. */
+        MemberEntity?: EntityKey,
+    }
+
+    interface JoinLobbyResult {
+        /** Successfully joined lobby's id. */
+        LobbyId: string,
+    }
+
+    /**
+     * Add the player to a matchmaking ticket and specify all of its matchmaking attributes. Players can join a ticket if and
+     * only if their EntityKeys are already listed in the ticket's Members list. The matchmaking service automatically starts
+     * matching the ticket against other matchmaking tickets once all players have joined the ticket. It is not possible to
+     * join a ticket once it has started matching.
+     */
+    interface JoinMatchmakingTicketRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The User who wants to join the ticket. Their Id must be listed in PlayFabIdsToMatchWith. */
+        Member: MatchmakingPlayer,
+        /** The name of the queue to join. */
+        QueueName: string,
+        /** The Id of the ticket to find a match for. */
+        TicketId: string,
+    }
+
+    interface JoinMatchmakingTicketResult {
+    }
+
+    /**
+     * Preview: Request for server to leave a lobby. Only a game_server entity can leave and this is restricted to client owned
+     * lobbies which are using connections.
+     */
+    interface LeaveLobbyAsServerRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The id of the lobby. */
+        LobbyId: string,
+        /**
+         * The game_server entity leaving the lobby. If the game_server was subscribed to notifications, it will be unsubscribed.
+         * If a the given game_server entity is not in the lobby, it will fail.
+         */
+        ServerEntity: EntityKey,
+    }
+
+    /** Request to leave a lobby. Only a client can leave a lobby. */
+    interface LeaveLobbyRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The id of the lobby. */
+        LobbyId?: string,
+        /** The member entity leaving the lobby. */
+        MemberEntity?: EntityKey,
+    }
+
+    interface LinearDifferenceRuleExpansion {
+        /** This value gets added to Difference at every expansion interval. */
+        Delta: number,
+        /** Once the total difference reaches this value, expansion stops. Optional. */
+        Limit?: number,
+        /** How many seconds before this rule is expanded. */
+        SecondsBetweenExpansions: number,
+    }
+
+    interface LinearRegionSelectionRuleExpansion {
+        /** This value gets added to MaxLatency at every expansion interval. */
+        Delta: number,
+        /** Once the max Latency reaches this value, expansion stops. */
+        Limit: number,
+        /** How many seconds before this rule is expanded. */
+        SecondsBetweenExpansions: number,
+    }
+
+    interface LinearSetIntersectionRuleExpansion {
+        /** This value gets added to MinIntersectionSize at every expansion interval. */
+        Delta: number,
+        /** How many seconds before this rule is expanded. */
+        SecondsBetweenExpansions: number,
+    }
+
+    interface LinearTeamDifferenceRuleExpansion {
+        /** This value gets added to Difference at every expansion interval. */
+        Delta: number,
+        /** Once the total difference reaches this value, expansion stops. Optional. */
+        Limit?: number,
+        /** How many seconds before this rule is expanded. */
+        SecondsBetweenExpansions: number,
+    }
+
+    interface LinearTeamSizeBalanceRuleExpansion {
+        /** This value gets added to Difference at every expansion interval. */
+        Delta: number,
+        /** Once the total difference reaches this value, expansion stops. Optional. */
+        Limit?: number,
+        /** How many seconds before this rule is expanded. */
+        SecondsBetweenExpansions: number,
+    }
+
+    interface LinuxInstrumentationConfiguration {
+        /** Designates whether Linux instrumentation configuration will be enabled for this Build */
+        IsEnabled: boolean,
+    }
+
+    /** Returns a list of multiplayer server game asset summaries for a title. */
+    interface ListAssetSummariesRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The page size for the request. */
+        PageSize?: number,
+        /** The skip token for the paged request. */
+        SkipToken?: string,
+    }
+
+    interface ListAssetSummariesResponse {
+        /** The list of asset summaries. */
+        AssetSummaries?: AssetSummary[],
+        /** The page size on the response. */
+        PageSize: number,
+        /** The skip token for the paged response. */
+        SkipToken?: string,
+    }
+
+    /** Returns a list of summarized details of all multiplayer server builds for a title. */
+    interface ListBuildAliasesRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The page size for the request. */
+        PageSize?: number,
+        /** The skip token for the paged request. */
+        SkipToken?: string,
+    }
+
+    interface ListBuildAliasesResponse {
+        /** The list of build aliases for the title */
+        BuildAliases?: BuildAliasDetailsResponse[],
+        /** The page size on the response. */
+        PageSize: number,
+        /** The skip token for the paged response. */
+        SkipToken?: string,
+    }
+
+    /** Returns a list of summarized details of all multiplayer server builds for a title. */
+    interface ListBuildSummariesRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The page size for the request. */
+        PageSize?: number,
+        /** The skip token for the paged request. */
+        SkipToken?: string,
+    }
+
+    interface ListBuildSummariesResponse {
+        /** The list of build summaries for a title. */
+        BuildSummaries?: BuildSummary[],
+        /** The page size on the response. */
+        PageSize: number,
+        /** The skip token for the paged response. */
+        SkipToken?: string,
+    }
+
+    /** Returns a list of multiplayer server game certificates for a title. */
+    interface ListCertificateSummariesRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The page size for the request. */
+        PageSize?: number,
+        /** The skip token for the paged request. */
+        SkipToken?: string,
+    }
+
+    interface ListCertificateSummariesResponse {
+        /** The list of game certificates. */
+        CertificateSummaries?: CertificateSummary[],
+        /** The page size on the response. */
+        PageSize: number,
+        /** The skip token for the paged response. */
+        SkipToken?: string,
+    }
+
+    /** Returns a list of the container images that have been uploaded to the container registry for a title. */
+    interface ListContainerImagesRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The page size for the request. */
+        PageSize?: number,
+        /** The skip token for the paged request. */
+        SkipToken?: string,
+    }
+
+    interface ListContainerImagesResponse {
+        /** The list of container images. */
+        Images?: string[],
+        /** The page size on the response. */
+        PageSize: number,
+        /** The skip token for the paged response. */
+        SkipToken?: string,
+    }
+
+    /** Returns a list of the tags for a particular container image that exists in the container registry for a title. */
+    interface ListContainerImageTagsRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The container images we want to list tags for. */
+        ImageName?: string,
+        /** The page size for the request. */
+        PageSize?: number,
+        /** The skip token for the paged request. */
+        SkipToken?: string,
+    }
+
+    interface ListContainerImageTagsResponse {
+        /** The page size on the response. */
+        PageSize: number,
+        /** The skip token for the paged response. */
+        SkipToken?: string,
+        /** The list of tags for a particular container image. */
+        Tags?: string[],
+    }
+
+    /** Gets a list of all the matchmaking queue configurations for the title. */
+    interface ListMatchmakingQueuesRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+    }
+
+    interface ListMatchmakingQueuesResult {
+        /** The list of matchmaking queue configs for this title. */
+        MatchMakingQueues?: MatchmakingQueueConfig[],
+    }
+
+    /**
+     * If the caller is a title, the EntityKey in the request is required. If the caller is a player, then it is optional. If
+     * it is provided it must match the caller's entity.
+     */
+    interface ListMatchmakingTicketsForPlayerRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The entity key for which to find the ticket Ids. */
+        Entity?: EntityKey,
+        /** The name of the queue to find a match for. */
+        QueueName: string,
+    }
+
+    interface ListMatchmakingTicketsForPlayerResult {
+        /** The list of ticket Ids the user is a member of. */
+        TicketIds: string[],
+    }
+
+    /** Returns a list of multiplayer servers for a build in a specific region. */
+    interface ListMultiplayerServersRequest {
+        /** The guid string build ID of the multiplayer servers to list. */
+        BuildId: string,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The page size for the request. */
+        PageSize?: number,
+        /** The region the multiplayer servers to list. */
+        Region: string,
+        /** The skip token for the paged request. */
+        SkipToken?: string,
+    }
+
+    interface ListMultiplayerServersResponse {
+        /** The list of multiplayer server summary details. */
+        MultiplayerServerSummaries?: MultiplayerServerSummary[],
+        /** The page size on the response. */
+        PageSize: number,
+        /** The skip token for the paged response. */
+        SkipToken?: string,
+    }
+
+    /** Returns a list of quality of service servers for party. */
+    interface ListPartyQosServersRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+    }
+
+    interface ListPartyQosServersResponse {
+        /** The page size on the response. */
+        PageSize: number,
+        /** The list of QoS servers. */
+        QosServers?: QosServer[],
+        /** The skip token for the paged response. */
+        SkipToken?: string,
+    }
+
+    /** Returns a list of quality of service servers for a title. */
+    interface ListQosServersForTitleRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /**
+         * Indicates that the response should contain Qos servers for all regions, including those where there are no builds
+         * deployed for the title.
+         */
+        IncludeAllRegions?: boolean,
+        /** Indicates the Routing Preference used by the Qos servers. The default Routing Preference is Microsoft */
+        RoutingPreference?: string,
+    }
+
+    interface ListQosServersForTitleResponse {
+        /** The page size on the response. */
+        PageSize: number,
+        /** The list of QoS servers. */
+        QosServers?: QosServer[],
+        /** The skip token for the paged response. */
+        SkipToken?: string,
+    }
+
+    /** Returns a list of multiplayer server game secrets for a title. */
+    interface ListSecretSummariesRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The page size for the request. */
+        PageSize?: number,
+        /** The skip token for the paged request. */
+        SkipToken?: string,
+    }
+
+    interface ListSecretSummariesResponse {
+        /** The page size on the response. */
+        PageSize: number,
+        /** The list of game secret. */
+        SecretSummaries?: SecretSummary[],
+        /** The skip token for the paged response. */
+        SkipToken?: string,
+    }
+
+    /** List all server backfill ticket Ids the user is a member of. */
+    interface ListServerBackfillTicketsForPlayerRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The entity key for which to find the ticket Ids. */
+        Entity: EntityKey,
+        /** The name of the queue the tickets are in. */
+        QueueName: string,
+    }
+
+    interface ListServerBackfillTicketsForPlayerResult {
+        /** The list of backfill ticket Ids the user is a member of. */
+        TicketIds: string[],
+    }
+
+    /** List all server quota change requests for a title. */
+    interface ListTitleMultiplayerServersQuotaChangesRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+    }
+
+    interface ListTitleMultiplayerServersQuotaChangesResponse {
+        /** All change requests for this title. */
+        Changes?: QuotaChange[],
+    }
+
+    /** Returns a list of virtual machines for a title. */
+    interface ListVirtualMachineSummariesRequest {
+        /** The guid string build ID of the virtual machines to list. */
+        BuildId: string,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The page size for the request. */
+        PageSize?: number,
+        /** The region of the virtual machines to list. */
+        Region: string,
+        /** The skip token for the paged request. */
+        SkipToken?: string,
+    }
+
+    interface ListVirtualMachineSummariesResponse {
+        /** The page size on the response. */
+        PageSize: number,
+        /** The skip token for the paged response. */
+        SkipToken?: string,
+        /** The list of virtual machine summaries. */
+        VirtualMachines?: VirtualMachineSummary[],
+    }
+
+    interface Lobby {
+        /** A setting indicating who is allowed to join this lobby, as well as see it in queries. */
+        AccessPolicy: AccessPolicy,
+        /** A number that increments once for each request that modifies the lobby. */
+        ChangeNumber: number,
+        /**
+         * A string used to join the lobby. This field is populated by the Lobby service. Invites are performed by communicating
+         * this connectionString to other players.
+         */
+        ConnectionString: string,
+        /** Lobby data. */
+        LobbyData?: { [key: string]: string | null },
+        /** Id to uniquely identify a lobby. */
+        LobbyId: string,
+        /** The maximum number of players allowed in the lobby. */
+        MaxPlayers: number,
+        /** Array of all lobby members. */
+        Members?: Member[],
+        /** A setting indicating whether members are allowed to join this lobby. When Locked new members are prevented from joining. */
+        MembershipLock: MembershipLock,
+        /** The client or server entity which owns this lobby. */
+        Owner?: EntityKey,
+        /** A setting indicating the owner migration policy. If server owned, this field is not present. */
+        OwnerMigrationPolicy?: OwnerMigrationPolicy,
+        /**
+         * An opaque string stored on a SubscribeToLobbyResource call, which indicates the connection an owner or member has with
+         * PubSub.
+         */
+        PubSubConnectionHandle?: string,
+        /**
+         * A setting that controls lobby invites. When true only owners can invite new players, when false all members area allowed
+         * to invite.
+         */
+        RestrictInvitesToLobbyOwner: boolean,
+        /** Search data. */
+        SearchData?: { [key: string]: string | null },
+        /** Preview: Lobby joined server. This is not the server owner, rather the server that has joined a client owned lobby. */
+        Server?: LobbyServer,
+        /** A flag which determines if connections are used. Defaults to true. Only set on create. */
+        UseConnections: boolean,
+    }
+
+    interface LobbyEmptyResult {
+    }
+
+    interface LobbyServer {
+        /** Opaque string, stored on a Subscribe call, which indicates the connection a joined server has with PubSub. */
+        PubSubConnectionHandle?: string,
+        /** Key-value pairs specific to the joined server. */
+        ServerData?: { [key: string]: string | null },
+        /** The server entity key. */
+        ServerEntity?: EntityKey,
+    }
+
+    interface LobbySummary {
+        /**
+         * A string used to join the lobby.This field is populated by the Lobby service.Invites are performed by communicating this
+         * connectionString to other players.
+         */
+        ConnectionString: string,
+        /** The current number of players in the lobby. */
+        CurrentPlayers: number,
+        /** Id to uniquely identify a lobby. */
+        LobbyId: string,
+        /** The maximum number of players allowed in the lobby. */
+        MaxPlayers: number,
+        /** A setting indicating whether members are allowed to join this lobby. When Locked new members are prevented from joining. */
+        MembershipLock?: MembershipLock,
+        /** The client or server entity which owns this lobby. */
+        Owner: EntityKey,
+        /** Search data. */
+        SearchData?: { [key: string]: string | null },
+    }
+
+    /** A user in a matchmaking ticket. */
+    interface MatchmakingPlayer {
+        /** The user's attributes custom to the title. */
+        Attributes?: MatchmakingPlayerAttributes,
+        /** The entity key of the matchmaking user. */
+        Entity: EntityKey,
+    }
+
+    /** The matchmaking attributes for a user. */
+    interface MatchmakingPlayerAttributes {
+        /** A data object representing a user's attributes. */
+        DataObject?: any,
+        /** An escaped data object representing a user's attributes. */
+        EscapedDataObject?: string,
+    }
+
+    /** A player in a created matchmaking match with a team assignment. */
+    interface MatchmakingPlayerWithTeamAssignment {
+        /**
+         * The user's attributes custom to the title. These attributes will be null unless the request has ReturnMemberAttributes
+         * flag set to true.
+         */
+        Attributes?: MatchmakingPlayerAttributes,
+        /** The entity key of the matchmaking user. */
+        Entity: EntityKey,
+        /** The Id of the team the User is assigned to. */
+        TeamId?: string,
+    }
+
+    interface MatchmakingQueueConfig {
+        /** This is the buildAlias that will be used to allocate the multiplayer server for the match. */
+        BuildAliasParams?: BuildAliasParams,
+        /** This is the buildId that will be used to allocate the multiplayer server for the match. */
+        BuildId?: string,
+        /** List of difference rules used to find an optimal match. */
+        DifferenceRules?: DifferenceRule[],
+        /** List of match total rules used to find an optimal match. */
+        MatchTotalRules?: MatchTotalRule[],
+        /** Maximum number of players in a match. */
+        MaxMatchSize: number,
+        /** Maximum number of players in a ticket. Optional. */
+        MaxTicketSize?: number,
+        /** Minimum number of players in a match. */
+        MinMatchSize: number,
+        /** Unique identifier for a Queue. Chosen by the developer. */
+        Name: string,
+        /** Region selection rule used to find an optimal match. */
+        RegionSelectionRule?: RegionSelectionRule,
+        /** Boolean flag to enable server allocation for the queue. */
+        ServerAllocationEnabled: boolean,
+        /** List of set intersection rules used to find an optimal match. */
+        SetIntersectionRules?: SetIntersectionRule[],
+        /** Controls which statistics are visible to players. */
+        StatisticsVisibilityToPlayers?: StatisticsVisibilityToPlayers,
+        /** List of string equality rules used to find an optimal match. */
+        StringEqualityRules?: StringEqualityRule[],
+        /** List of team difference rules used to find an optimal match. */
+        TeamDifferenceRules?: TeamDifferenceRule[],
+        /** The team configuration for a match. This may be null if there are no teams. */
+        Teams?: MatchmakingQueueTeam[],
+        /** Team size balance rule used to find an optimal match. */
+        TeamSizeBalanceRule?: TeamSizeBalanceRule,
+        /** Team ticket size similarity rule used to find an optimal match. */
+        TeamTicketSizeSimilarityRule?: TeamTicketSizeSimilarityRule,
+    }
+
+    interface MatchmakingQueueTeam {
+        /** The maximum number of players required for the team. */
+        MaxTeamSize: number,
+        /** The minimum number of players required for the team. */
+        MinTeamSize: number,
+        /** A name to identify the team. This is case insensitive. */
+        Name: string,
+    }
+
+    interface MatchTotalRule {
+        /** Description of the attribute used by this rule to match tickets. */
+        Attribute: QueueRuleAttribute,
+        /** Collection of fields relating to expanding this rule at set intervals. */
+        Expansion?: MatchTotalRuleExpansion,
+        /** The maximum total value for a group. Must be &gt;= Min. */
+        Max: number,
+        /** The minimum total value for a group. Must be &gt;=2. */
+        Min: number,
+        /** Friendly name chosen by developer. */
+        Name: string,
+        /**
+         * How many seconds before this rule is no longer enforced (but tickets that comply with this rule will still be
+         * prioritized over those that don't). Leave blank if this rule is always enforced.
+         */
+        SecondsUntilOptional?: number,
+        /** The relative weight of this rule compared to others. */
+        Weight: number,
+    }
+
+    interface MatchTotalRuleExpansion {
+        /** Manually specify the values to use for each expansion interval. When this is set, Max is ignored. */
+        MaxOverrides?: OverrideDouble[],
+        /** Manually specify the values to use for each expansion interval. When this is set, Min is ignored. */
+        MinOverrides?: OverrideDouble[],
+        /** How many seconds before this rule is expanded. */
+        SecondsBetweenExpansions: number,
+    }
+
+    interface Member {
+        /** Key-value pairs specific to member. */
+        MemberData?: { [key: string]: string | null },
+        /** The member entity key. */
+        MemberEntity?: EntityKey,
+        /** Opaque string, stored on a Subscribe call, which indicates the connection an owner or member has with PubSub. */
+        PubSubConnectionHandle?: string,
+    }
+
+    type MembershipLock = "Unlocked"
+
+        | "Locked";
+
+    interface MonitoringApplicationConfiguration {
+        /** Asset which contains the monitoring application files and scripts. */
+        AssetReference: AssetReference,
+        /** Execution script name, this will be the main executable for the monitoring application. */
+        ExecutionScriptName: string,
+        /** Installation script name, this will be run before the ExecutionScript. */
+        InstallationScriptName?: string,
+        /** Timespan the monitoring application will be kept alive when running from the start of the VM */
+        OnStartRuntimeInMinutes?: number,
+    }
+
+    interface MonitoringApplicationConfigurationParams {
+        /** Asset which contains the monitoring application files and scripts. */
+        AssetReference: AssetReferenceParams,
+        /** Execution script name, this will be the main executable for the monitoring application. */
+        ExecutionScriptName: string,
+        /** Installation script name, this will be run before the ExecutionScript. */
+        InstallationScriptName?: string,
+        /** Timespan the monitoring application will be kept alive when running from the start of the VM */
+        OnStartRuntimeInMinutes?: number,
+    }
+
+    interface MultiplayerServerSummary {
+        /** The connected players in the multiplayer server. */
+        ConnectedPlayers?: ConnectedPlayer[],
+        /** The time (UTC) at which a change in the multiplayer server state was observed. */
+        LastStateTransitionTime?: string,
+        /** The region the multiplayer server is located in. */
+        Region?: string,
+        /** The string server ID of the multiplayer server generated by PlayFab. */
+        ServerId?: string,
+        /** The title generated guid string session ID of the multiplayer server. */
+        SessionId?: string,
+        /** The state of the multiplayer server. */
+        State?: string,
+        /** The virtual machine ID that the multiplayer server is located on. */
+        VmId?: string,
+    }
+
+    type OsPlatform = "Windows"
+
+        | "Linux";
+
+    interface OverrideDouble {
+        /** The custom expansion value. */
+        Value: number,
+    }
+
+    interface OverrideUnsignedInt {
+        /** The custom expansion value. */
+        Value: number,
+    }
+
+    type OwnerMigrationPolicy = "None"
+
+        | "Automatic"
+        | "Manual"
+        | "Server";
+
+    interface PaginationRequest {
+        /** Continuation token returned as a result in a previous FindLobbies call. Cannot be specified by clients. */
+        ContinuationToken?: string,
+        /** The number of lobbies that should be retrieved. Cannot be specified by servers, clients may specify any value up to 50 */
+        PageSizeRequested?: number,
+    }
+
+    interface PaginationResponse {
+        /** Continuation token returned by server call. Not returned for clients */
+        ContinuationToken?: string,
+        /** The number of lobbies that matched the search request. */
+        TotalMatchedLobbyCount?: number,
+    }
+
+    interface PartyInvitationConfiguration {
+        /**
+         * The list of PlayFab EntityKeys that the invitation allows to authenticate into the network. If this list is empty, all
+         * users are allowed to authenticate using the invitation's identifier. This list may contain no more than 1024 items.
+         */
+        EntityKeys?: EntityKey[],
+        /** The invite identifier for this party. If this value is specified, it must be no longer than 127 characters. */
+        Identifier?: string,
+        /** Controls which participants can revoke this invite. */
+        Revocability?: string,
+    }
+
+    type PartyInvitationRevocability = "Creator"
+
+        | "Anyone";
+
+    interface PartyNetworkConfiguration {
+        /** Controls whether and how to support direct peer-to-peer connection attempts among devices in the network. */
+        DirectPeerConnectivityOptions?: string,
+        /** The maximum number of devices allowed to connect to the network. Must be between 1 and 128, inclusive. */
+        MaxDevices: number,
+        /** The maximum number of devices allowed per user. Must be greater than 0. */
+        MaxDevicesPerUser: number,
+        /** The maximum number of endpoints allowed per device. Must be between 0 and 32, inclusive. */
+        MaxEndpointsPerDevice: number,
+        /** The maximum number of unique users allowed in the network. Must be greater than 0. */
+        MaxUsers: number,
+        /** The maximum number of users allowed per device. Must be between 1 and 8, inclusive. */
+        MaxUsersPerDevice: number,
+        /**
+         * An optionally-specified configuration for the initial invitation for this party. If not provided, default configuration
+         * values will be used: a title-unique invitation identifier will be generated, the revocability will be Anyone, and the
+         * EntityID list will be empty.
+         */
+        PartyInvitationConfiguration?: PartyInvitationConfiguration,
+    }
+
+    interface Port {
+        /** The name for the port. */
+        Name: string,
+        /** The number for the port. */
+        Num: number,
+        /** The protocol for the port. */
+        Protocol: ProtocolType,
+    }
+
+    type ProtocolType = "TCP"
+
+        | "UDP";
+
+    interface PublicIpAddress {
+        /** FQDN of the public IP */
+        FQDN: string,
+        /** Server IP Address */
+        IpAddress: string,
+        /** Routing Type of the public IP. */
+        RoutingType: string,
+    }
+
+    interface QosServer {
+        /** The region the QoS server is located in. */
+        Region?: string,
+        /** The QoS server URL. */
+        ServerUrl?: string,
+    }
+
+    interface QueueRuleAttribute {
+        /** Specifies which attribute in a ticket to use. */
+        Path: string,
+        /** Specifies which source the attribute comes from. */
+        Source: AttributeSource,
+    }
+
+    interface QuotaChange {
+        /** A brief description of the requested changes. */
+        ChangeDescription?: string,
+        /** Requested changes to make to the titles cores quota. */
+        Changes?: CoreCapacityChange[],
+        /** Whether or not this request is pending a review. */
+        IsPendingReview: boolean,
+        /** Additional information about this request that our team can use to better understand the requirements. */
+        Notes?: string,
+        /** Id of the change request. */
+        RequestId?: string,
+        /** Comments by our team when a request is reviewed. */
+        ReviewComments?: string,
+        /** Whether or not this request was approved. */
+        WasApproved: boolean,
+    }
+
+    interface RegionSelectionRule {
+        /**
+         * Controls how the Max Latency parameter expands over time. Only one expansion can be set per rule. When this is set,
+         * MaxLatency is ignored.
+         */
+        CustomExpansion?: CustomRegionSelectionRuleExpansion,
+        /** Controls how the Max Latency parameter expands over time. Only one expansion can be set per rule. */
+        LinearExpansion?: LinearRegionSelectionRuleExpansion,
+        /** Specifies the maximum latency that is allowed between the client and the selected server. The value is in milliseconds. */
+        MaxLatency: number,
+        /** Friendly name chosen by developer. */
+        Name: string,
+        /** Specifies which attribute in a ticket to use. */
+        Path: string,
+        /**
+         * How many seconds before this rule is no longer enforced (but tickets that comply with this rule will still be
+         * prioritized over those that don't). Leave blank if this rule is always enforced.
+         */
+        SecondsUntilOptional?: number,
+        /** The relative weight of this rule compared to others. */
+        Weight: number,
+    }
+
+    /**
+     * Deletes the configuration for a queue. This will permanently delete the configuration and players will no longer be able
+     * to match in the queue. All outstanding matchmaking tickets will be cancelled.
+     */
+    interface RemoveMatchmakingQueueRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The Id of the matchmaking queue to remove. */
+        QueueName?: string,
+    }
+
+    interface RemoveMatchmakingQueueResult {
+    }
+
+    /**
+     * Request to remove a member from a lobby. Owners may remove other members from a lobby. Members cannot remove themselves
+     * (use LeaveLobby instead).
+     */
+    interface RemoveMemberFromLobbyRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The id of the lobby. */
+        LobbyId?: string,
+        /** The member entity to be removed from the lobby. */
+        MemberEntity?: EntityKey,
+        /** If true, removed member can never rejoin this lobby. */
+        PreventRejoin: boolean,
+    }
+
+    /** Requests a multiplayer server session from a particular build in any of the given preferred regions. */
+    interface RequestMultiplayerServerRequest {
+        /** The identifiers of the build alias to use for the request. */
+        BuildAliasParams?: BuildAliasParams,
+        /** The guid string build ID of the multiplayer server to request. */
+        BuildId?: string,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /**
+         * Initial list of players (potentially matchmade) allowed to connect to the game. This list is passed to the game server
+         * when requested (via GSDK) and can be used to validate players connecting to it.
+         */
+        InitialPlayers?: string[],
+        /**
+         * The preferred regions to request a multiplayer server from. The Multiplayer Service will iterate through the regions in
+         * the specified order and allocate a server from the first one that has servers available.
+         */
+        PreferredRegions: string[],
+        /**
+         * Data encoded as a string that is passed to the game server when requested. This can be used to communicate information
+         * such as game mode or map through the request flow. Maximum size is 8KB
+         */
+        SessionCookie?: string,
+        /** A guid string session ID created track the multiplayer server session over its life. */
+        SessionId: string,
+    }
+
+    interface RequestMultiplayerServerResponse {
+        /** The identity of the build in which the server was allocated. */
+        BuildId?: string,
+        /** The connected players in the multiplayer server. */
+        ConnectedPlayers?: ConnectedPlayer[],
+        /** The fully qualified domain name of the virtual machine that is hosting this multiplayer server. */
+        FQDN?: string,
+        /** The public IPv4 address of the virtual machine that is hosting this multiplayer server. */
+        IPV4Address?: string,
+        /** The time (UTC) at which a change in the multiplayer server state was observed. */
+        LastStateTransitionTime?: string,
+        /** The ports the multiplayer server uses. */
+        Ports?: Port[],
+        /** The list of public Ipv4 addresses associated with the server. */
+        PublicIPV4Addresses?: PublicIpAddress[],
+        /** The region the multiplayer server is located in. */
+        Region?: string,
+        /** The string server ID of the multiplayer server generated by PlayFab. */
+        ServerId?: string,
+        /** The guid string session ID of the multiplayer server. */
+        SessionId?: string,
+        /** The state of the multiplayer server. */
+        State?: string,
+        /** The virtual machine ID that the multiplayer server is located on. */
+        VmId?: string,
+    }
+
+    /**
+     * Requests a party session from a particular set of builds if build alias params is provided, in any of the given
+     * preferred regions.
+     */
+    interface RequestPartyServiceRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The network configuration for this request. */
+        NetworkConfiguration: PartyNetworkConfiguration,
+        /** A guid string party ID created track the party session over its life. */
+        PartyId?: string,
+        /** A player entity Id on behalf of whom the request is being made. */
+        PlayFabId?: string,
+        /**
+         * The preferred regions to request a party session from. The party service will iterate through the regions in the
+         * specified order and allocate a party session from the first one that is available.
+         */
+        PreferredRegions: string[],
+    }
+
+    interface RequestPartyServiceResponse {
+        /**
+         * The invitation identifier supplied in the PartyInvitationConfiguration, or the PlayFab-generated guid if none was
+         * supplied.
+         */
+        InvitationId?: string,
+        /** The guid string party ID of the party session. */
+        PartyId?: string,
+        /** A base-64 encoded string containing the serialized network descriptor for this party. */
+        SerializedNetworkDescriptor?: string,
+    }
+
+    /**
+     * Gets new credentials to the container registry where game developers can upload custom container images to before
+     * creating a new build.
+     */
+    interface RolloverContainerRegistryCredentialsRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+    }
+
+    interface RolloverContainerRegistryCredentialsResponse {
+        /** The url of the container registry. */
+        DnsName?: string,
+        /** The password for accessing the container registry. */
+        Password?: string,
+        /** The username for accessing the container registry. */
+        Username?: string,
+    }
+
+    type RoutingType = "Microsoft"
+
+        | "Internet";
+
+    interface Schedule {
+        /** A short description about this schedule. For example, "Game launch on July 15th". */
+        Description?: string,
+        /**
+         * The date and time in UTC at which the schedule ends. If IsRecurringWeekly is true, this schedule will keep renewing for
+         * future weeks until disabled or removed.
+         */
+        EndTime: string,
+        /** Disables the schedule. */
+        IsDisabled: boolean,
+        /** If true, the StartTime and EndTime will get renewed every week. */
+        IsRecurringWeekly: boolean,
+        /** The date and time in UTC at which the schedule starts. */
+        StartTime: string,
+        /** The standby target to maintain for the duration of the schedule. */
+        TargetStandby: number,
+    }
+
+    interface ScheduledStandbySettings {
+        /** When true, scheduled standby will be enabled */
+        IsEnabled: boolean,
+        /** A list of non-overlapping schedules */
+        ScheduleList?: Schedule[],
+    }
+
+    interface Secret {
+        /** Optional secret expiration date. */
+        ExpirationDate?: string,
+        /** A name for the secret. This is used to reference secrets in build configurations. */
+        Name: string,
+        /** Secret value. */
+        Value: string,
+    }
+
+    interface SecretSummary {
+        /** Optional secret expiration date. */
+        ExpirationDate?: string,
+        /** The name of the secret. */
+        Name?: string,
+        /** The secret version auto-generated after upload. */
+        Version?: string,
+    }
+
+    interface ServerDetails {
+        /** The fully qualified domain name of the virtual machine that is hosting this multiplayer server. */
+        Fqdn?: string,
+        /** The IPv4 address of the virtual machine that is hosting this multiplayer server. */
+        IPV4Address?: string,
+        /** The ports the multiplayer server uses. */
+        Ports?: Port[],
+        /** The server's region. */
+        Region?: string,
+        /** The string server ID of the multiplayer server generated by PlayFab. */
+        ServerId?: string,
+    }
+
+    interface ServerResourceConstraintParams {
+        /** The maximum number of cores that each server is allowed to use. */
+        CpuLimit: number,
+        /**
+         * The maximum number of GiB of memory that each server is allowed to use. WARNING: After exceeding this limit, the server
+         * will be killed
+         */
+        MemoryLimitGB: number,
+    }
+
+    type ServerType = "Container"
+
+        | "Process";
+
+    interface SetIntersectionRule {
+        /** Description of the attribute used by this rule to match tickets. */
+        Attribute: QueueRuleAttribute,
+        /**
+         * Describes the behavior when an attribute is not specified in the ticket creation request or in the user's entity
+         * profile.
+         */
+        AttributeNotSpecifiedBehavior: AttributeNotSpecifiedBehavior,
+        /**
+         * Collection of fields relating to expanding this rule at set intervals. Only one expansion can be set per rule. When this
+         * is set, MinIntersectionSize is ignored.
+         */
+        CustomExpansion?: CustomSetIntersectionRuleExpansion,
+        /**
+         * The default value assigned to tickets that are missing the attribute specified by AttributePath (assuming that
+         * AttributeNotSpecifiedBehavior is UseDefault). Values must be unique.
+         */
+        DefaultAttributeValue?: string[],
+        /** Collection of fields relating to expanding this rule at set intervals. Only one expansion can be set per rule. */
+        LinearExpansion?: LinearSetIntersectionRuleExpansion,
+        /** The minimum number of values that must match between sets. */
+        MinIntersectionSize: number,
+        /** Friendly name chosen by developer. */
+        Name: string,
+        /**
+         * How many seconds before this rule is no longer enforced (but tickets that comply with this rule will still be
+         * prioritized over those that don't). Leave blank if this rule is always enforced.
+         */
+        SecondsUntilOptional?: number,
+        /** The relative weight of this rule compared to others. */
+        Weight: number,
+    }
+
+    /**
+     * Use this API to create or update matchmaking queue configurations. The queue configuration defines the matchmaking
+     * rules. The matchmaking service will match tickets together according to the configured rules. Queue resources are not
+     * spun up by calling this API. Queues are created when the first ticket is submitted.
+     */
+    interface SetMatchmakingQueueRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The matchmaking queue config. */
+        MatchmakingQueue: MatchmakingQueueConfig,
+    }
+
+    interface SetMatchmakingQueueResult {
+    }
+
+    /**
+     * Executes the shutdown callback from the GSDK and terminates the multiplayer server session. The callback in the GSDK
+     * will allow for graceful shutdown with a 15 minute timeoutIf graceful shutdown has not been completed before 15 minutes
+     * have elapsed, the multiplayer server session will be forcefully terminated on it's own.
+     */
+    interface ShutdownMultiplayerServerRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** A guid string session ID of the multiplayer server to shut down. */
+        SessionId: string,
+    }
+
+    interface Statistics {
+        /** The average. */
+        Average: number,
+        /** The 50th percentile. */
+        Percentile50: number,
+        /** The 90th percentile. */
+        Percentile90: number,
+        /** The 99th percentile. */
+        Percentile99: number,
+    }
+
+    interface StatisticsVisibilityToPlayers {
+        /** Whether to allow players to view the current number of players in the matchmaking queue. */
+        ShowNumberOfPlayersMatching: boolean,
+        /** Whether to allow players to view statistics representing the time it takes for tickets to find a match. */
+        ShowTimeToMatch: boolean,
+    }
+
+    interface StringEqualityRule {
+        /** Description of the attribute used by this rule to match tickets. */
+        Attribute: QueueRuleAttribute,
+        /**
+         * Describes the behavior when an attribute is not specified in the ticket creation request or in the user's entity
+         * profile.
+         */
+        AttributeNotSpecifiedBehavior: AttributeNotSpecifiedBehavior,
+        /**
+         * The default value assigned to tickets that are missing the attribute specified by AttributePath (assuming that
+         * AttributeNotSpecifiedBehavior is false).
+         */
+        DefaultAttributeValue?: string,
+        /**
+         * Collection of fields relating to expanding this rule at set intervals. For StringEqualityRules, this is limited to
+         * turning the rule off or on during different intervals.
+         */
+        Expansion?: StringEqualityRuleExpansion,
+        /** Friendly name chosen by developer. */
+        Name: string,
+        /**
+         * How many seconds before this rule is no longer enforced (but tickets that comply with this rule will still be
+         * prioritized over those that don't). Leave blank if this rule is always enforced.
+         */
+        SecondsUntilOptional?: number,
+        /** The relative weight of this rule compared to others. */
+        Weight: number,
+    }
+
+    interface StringEqualityRuleExpansion {
+        /** List of bools specifying whether the rule is applied during this expansion. */
+        EnabledOverrides: boolean[],
+        /** How many seconds before this rule is expanded. */
+        SecondsBetweenExpansions: number,
+    }
+
+    /** Request to subscribe to lobby resource notifications. */
+    interface SubscribeToLobbyResourceRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The entity performing the subscription. */
+        EntityKey: EntityKey,
+        /** Opaque string, given to a client upon creating a connection with PubSub. */
+        PubSubConnectionHandle: string,
+        /**
+         * The name of the resource to subscribe to. For LobbyChange subscriptions this is the lobbyId. For LobbyInvite
+         * subscriptions this should always be "@me".
+         */
+        ResourceId: string,
+        /** Version number for the subscription of this resource. */
+        SubscriptionVersion: number,
+        /**
+         * Subscription type. "LobbyChange" subscriptions allow a member or owner to receive notifications of lobby data, member or
+         * owner changes. "LobbyInvite" subscriptions allow a player to receive invites to lobbies. A player does not need to be a
+         * member of a lobby to receive lobby invites.
+         */
+        Type: SubscriptionType,
+    }
+
+    interface SubscribeToLobbyResourceResult {
+        /** Topic will be returned in all notifications that are the result of this subscription. */
+        Topic: string,
+    }
+
+    /** Subscribe to match resource notifications. Match subscriptions have two types; MatchInvite and MatchTicketStatusChange */
+    interface SubscribeToMatchResourceRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The entity performing the subscription. The entity must be authorized to use this connectionHandle. */
+        EntityKey: EntityKey,
+        /**
+         * Opaque string, given to a client upon creating a connection with PubSub. Notifications will be sent to the connection
+         * associated with this handle.
+         */
+        PubSubConnectionHandle: string,
+        /**
+         * The name of the resource to subscribe to. It follows the format {queueName}|{ticketId} for MatchTicketStatusChange. For
+         * MatchInvite, ResourceId is @me.
+         */
+        ResourceId: string,
+        /** Version number for the subscription of this resource. Current supported version must be 1. */
+        SubscriptionVersion: number,
+        /**
+         * Subscription type. MatchInvite subscriptions are per-player. MatchTicketStatusChange subscriptions are per-ticket.
+         * Subscribe calls are idempotent. Subscribing on the same resource for the same connection results in success.
+         */
+        Type: string,
+    }
+
+    interface SubscribeToMatchResourceResult {
+        /** Matchmaking resource */
+        Topic: string,
+    }
+
+    type SubscriptionType = "LobbyChange"
+
+        | "LobbyInvite";
+
+    interface TeamDifferenceRule {
+        /** Description of the attribute used by this rule to match teams. */
+        Attribute: QueueRuleAttribute,
+        /**
+         * Collection of fields relating to expanding this rule at set intervals. Only one expansion can be set per rule. When this
+         * is set, Difference is ignored.
+         */
+        CustomExpansion?: CustomTeamDifferenceRuleExpansion,
+        /**
+         * The default value assigned to tickets that are missing the attribute specified by AttributePath (assuming that
+         * AttributeNotSpecifiedBehavior is false).
+         */
+        DefaultAttributeValue: number,
+        /** The allowed difference between any two teams at the start of matchmaking. */
+        Difference: number,
+        /** Collection of fields relating to expanding this rule at set intervals. Only one expansion can be set per rule. */
+        LinearExpansion?: LinearTeamDifferenceRuleExpansion,
+        /** Friendly name chosen by developer. */
+        Name: string,
+        /**
+         * How many seconds before this rule is no longer enforced (but tickets that comply with this rule will still be
+         * prioritized over those that don't). Leave blank if this rule is always enforced.
+         */
+        SecondsUntilOptional?: number,
+    }
+
+    interface TeamSizeBalanceRule {
+        /**
+         * Controls how the Difference parameter expands over time. Only one expansion can be set per rule. When this is set,
+         * Difference is ignored.
+         */
+        CustomExpansion?: CustomTeamSizeBalanceRuleExpansion,
+        /** The allowed difference in team size between any two teams. */
+        Difference: number,
+        /** Controls how the Difference parameter expands over time. Only one expansion can be set per rule. */
+        LinearExpansion?: LinearTeamSizeBalanceRuleExpansion,
+        /** Friendly name chosen by developer. */
+        Name: string,
+        /**
+         * How many seconds before this rule is no longer enforced (but tickets that comply with this rule will still be
+         * prioritized over those that don't). Leave blank if this rule is always enforced.
+         */
+        SecondsUntilOptional?: number,
+    }
+
+    interface TeamTicketSizeSimilarityRule {
+        /** Friendly name chosen by developer. */
+        Name: string,
+        /**
+         * How many seconds before this rule is no longer enforced (but tickets that comply with this rule will still be
+         * prioritized over those that don't). Leave blank if this rule is always enforced.
+         */
+        SecondsUntilOptional?: number,
+    }
+
+    type TitleMultiplayerServerEnabledStatus = "Initializing"
+
+        | "Enabled"
+        | "Disabled";
+
+    interface TitleMultiplayerServersQuotas {
+        /** The core capacity for the various regions and VM Family */
+        CoreCapacities?: CoreCapacity[],
+    }
+
+    /** Request to unsubscribe from lobby notifications. */
+    interface UnsubscribeFromLobbyResourceRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The entity which performed the subscription. */
+        EntityKey: EntityKey,
+        /** Opaque string, given to a client upon creating a connection with PubSub. */
+        PubSubConnectionHandle: string,
+        /** The name of the resource to unsubscribe from. */
+        ResourceId: string,
+        /** Version number passed for the subscription of this resource. */
+        SubscriptionVersion: number,
+        /** Subscription type. */
+        Type: SubscriptionType,
+    }
+
+    /**
+     * Unsubscribe from a Match resource's notifications. For MatchInvite, players are expected to unsubscribe once they can no
+     * longer accept invites. For MatchTicketStatusChange, players are expected to unsusbcribe once the ticket has reached a
+     * canceled or matched state.
+     */
+    interface UnsubscribeFromMatchResourceRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The entity performing the unsubscription. The entity must be authorized to use this connectionHandle. */
+        EntityKey: EntityKey,
+        /** Opaque string, given to a client upon creating a connection with PubSub. */
+        PubSubConnectionHandle: string,
+        /**
+         * The name of the resource to unsubscribe from. It follows the format {queueName}|{ticketId} for MatchTicketStatusChange.
+         * For MatchInvite, ResourceId is @me.
+         */
+        ResourceId: string,
+        /** Version number for the unsubscription from this resource. */
+        SubscriptionVersion: number,
+        /** Type of the subscription to be canceled. */
+        Type: string,
+    }
+
+    interface UnsubscribeFromMatchResourceResult {
+    }
+
+    /**
+     * Removes the specified tag from the image. After this operation, a 'docker pull' will fail for the specified image and
+     * tag combination. Morever, ListContainerImageTags will not return the specified tag.
+     */
+    interface UntagContainerImageRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The container image which tag we want to remove. */
+        ImageName?: string,
+        /** The tag we want to remove. */
+        Tag?: string,
+    }
+
+    /** Creates a multiplayer server build alias and returns the created alias. */
+    interface UpdateBuildAliasRequest {
+        /** The guid string alias Id of the alias to be updated. */
+        AliasId: string,
+        /** The alias name. */
+        AliasName?: string,
+        /** Array of build selection criteria. */
+        BuildSelectionCriteria?: BuildSelectionCriterion[],
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+    }
+
+    /** Updates a multiplayer server build's name. */
+    interface UpdateBuildNameRequest {
+        /** The guid string ID of the build we want to update the name of. */
+        BuildId: string,
+        /** The build name. */
+        BuildName: string,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+    }
+
+    /** Updates a multiplayer server build's region. */
+    interface UpdateBuildRegionRequest {
+        /** The guid string ID of the build we want to update regions for. */
+        BuildId: string,
+        /** The updated region configuration that should be applied to the specified build. */
+        BuildRegion: BuildRegionParams,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+    }
+
+    /** Updates a multiplayer server build's regions. */
+    interface UpdateBuildRegionsRequest {
+        /** The guid string ID of the build we want to update regions for. */
+        BuildId: string,
+        /** The updated region configuration that should be applied to the specified build. */
+        BuildRegions: BuildRegionParams[],
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+    }
+
+    /**
+     * Preview: Request to update the serverData and serverEntity in case of migration. Only a game_server entity can update
+     * this information and this is restricted to client owned lobbies which are using connections.
+     */
+    interface UpdateLobbyAsServerRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** The id of the lobby. */
+        LobbyId: string,
+        /**
+         * The private key-value pairs which are visible to all entities in the lobby and modifiable by the joined server.
+         * Optional. Sets or updates key-value pairs on the lobby. Only the current lobby lobby server can set serverData. Keys may
+         * be an arbitrary string of at most 30 characters. The total size of all serverData values may not exceed 4096 bytes.
+         * Values are not individually limited. There can be up to 30 key-value pairs stored here. Keys are case sensitive.
+         */
+        ServerData?: { [key: string]: string | null },
+        /**
+         * The keys to delete from the lobby serverData. Optional. Optional. Deletes key-value pairs on the lobby. Only the current
+         * joined lobby server can delete serverData. All the specified keys will be removed from the serverData. Keys that do not
+         * exist in the lobby are a no-op. If the key to delete exists in the serverData (same request) it will result in a bad
+         * request.
+         */
+        ServerDataToDelete?: string[],
+        /**
+         * The lobby server. Optional. Set a different server as the joined server of the lobby (there can only be 1 joined
+         * server). When changing the server the previous server will automatically be unsubscribed.
+         */
+        ServerEntity?: EntityKey,
+    }
+
+    /** Request to update a lobby. */
+    interface UpdateLobbyRequest {
+        /**
+         * The policy indicating who is allowed to join the lobby, and the visibility to queries. May be 'Public', 'Friends' or
+         * 'Private'. Public means the lobby is both visible in queries and any player may join, including invited players. Friends
+         * means that users who are bidirectional friends of members in the lobby may search to find friend lobbies, to retrieve
+         * its connection string. Private means the lobby is not visible in queries, and a player must receive an invitation to
+         * join. Defaults to 'Public' on creation. Can only be changed by the lobby owner.
+         */
+        AccessPolicy?: AccessPolicy,
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /**
+         * The private key-value pairs which are visible to all entities in the lobby. Optional. Sets or updates key-value pairs on
+         * the lobby. Only the current lobby owner can set lobby data. Keys may be an arbitrary string of at most 30 characters.
+         * The total size of all lobbyData values may not exceed 4096 bytes. Values are not individually limited. There can be up
+         * to 30 key-value pairs stored here. Keys are case sensitive.
+         */
+        LobbyData?: { [key: string]: string | null },
+        /** The keys to delete from the lobby LobbyData. Optional. Behaves similar to searchDataToDelete, but applies to lobbyData. */
+        LobbyDataToDelete?: string[],
+        /** The id of the lobby. */
+        LobbyId?: string,
+        /**
+         * The maximum number of players allowed in the lobby. Updates the maximum allowed number of players in the lobby. Only the
+         * current lobby owner can set this. If set, the value must be greater than or equal to the number of members currently in
+         * the lobby.
+         */
+        MaxPlayers?: number,
+        /**
+         * The private key-value pairs used by the member to communicate information to other members and the owner. Optional. Sets
+         * or updates new key-value pairs on the caller's member data. New keys will be added with their values and existing keys
+         * will be updated with the new values. Visible to all entities in the lobby. At most 30 key-value pairs may be stored
+         * here, keys are limited to 30 characters and values to 1000. The total size of all memberData values may not exceed 4096
+         * bytes. Keys are case sensitive. Servers cannot specifiy this.
+         */
+        MemberData?: { [key: string]: string | null },
+        /**
+         * The keys to delete from the lobby MemberData. Optional. Deletes key-value pairs on the caller's member data. All the
+         * specified keys will be removed from the caller's member data. Keys that do not exist are a no-op. If the key to delete
+         * exists in the memberData (same request) it will result in a bad request. Servers cannot specifiy this.
+         */
+        MemberDataToDelete?: string[],
+        /** The member entity whose data is being modified. Servers cannot specify this. */
+        MemberEntity?: EntityKey,
+        /**
+         * A setting indicating whether the lobby is locked. May be 'Unlocked' or 'Locked'. When Locked new members are not allowed
+         * to join. Defaults to 'Unlocked' on creation. Can only be changed by the lobby owner.
+         */
+        MembershipLock?: MembershipLock,
+        /**
+         * The lobby owner. Optional. Set to transfer ownership of the lobby. If client - owned and 'Automatic' - The Lobby service
+         * will automatically assign another connected owner when the current owner leaves or disconnects. useConnections must be
+         * true. If client - owned and 'Manual' - Ownership is protected as long as the current owner is connected. If the current
+         * owner leaves or disconnects any member may set themselves as the current owner. The useConnections property must be
+         * true. If client-owned and 'None' - Any member can set ownership. The useConnections property can be either true or
+         * false. For all client-owned lobbies when the owner leaves and a new owner can not be automatically selected - The owner
+         * field is set to null. For all client-owned lobbies when the owner disconnects and a new owner can not be automatically
+         * selected - The owner field remains unchanged and the current owner retains all owner abilities for the lobby. If
+         * server-owned (must be 'Server') - Any server can set ownership. The useConnections property must be true.
+         */
+        Owner?: EntityKey,
+        /**
+         * A setting that controls whether only the lobby owner can send invites to join the lobby. When true, only the lobby owner
+         * can send invites. When false or not specified, any member can send invites. Will not modify current configuration if not
+         * specified. Restricted to client owned lobbies.
+         */
+        RestrictInvitesToLobbyOwner?: boolean,
+        /**
+         * The public key-value pairs which allow queries to differentiate between lobbies. Optional. Sets or updates key-value
+         * pairs on the lobby for use with queries. Only the current lobby owner can set search data. New keys will be added with
+         * their values and existing keys will be updated with the new values. There can be up to 30 key-value pairs stored here.
+         * Keys are of the format string_key1, string_key2... string_key30 for string values, or number_key1, number_key2, ...
+         * number_key30 for numeric values. Numeric values are floats. Values can be at most 256 characters long. The total size of
+         * all searchData values may not exceed 1024 bytes.Keys are case sensitive.
+         */
+        SearchData?: { [key: string]: string | null },
+        /**
+         * The keys to delete from the lobby SearchData. Optional. Deletes key-value pairs on the lobby. Only the current lobby
+         * owner can delete search data. All the specified keys will be removed from the search data. Keys that do not exist in the
+         * lobby are a no-op.If the key to delete exists in the searchData (same request) it will result in a bad request.
+         */
+        SearchDataToDelete?: string[],
+    }
+
+    /** Uploads a multiplayer server game certificate. */
+    interface UploadCertificateRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** Forces the certificate renewal if the certificate already exists. Default is false */
+        ForceUpdate?: boolean,
+        /** The game certificate to upload. */
+        GameCertificate: Certificate,
+    }
+
+    /** Uploads a multiplayer server game secret. */
+    interface UploadSecretRequest {
+        /** The optional custom tags associated with the request (e.g. build number, external trace identifiers, etc.). */
+        CustomTags?: { [key: string]: string | null },
+        /** Forces the secret renewal if the secret already exists. Default is false */
+        ForceUpdate?: boolean,
+        /** The game secret to add. */
+        GameSecret: Secret,
+    }
+
+    interface VirtualMachineSummary {
+        /** The virtual machine health status. */
+        HealthStatus?: string,
+        /** The virtual machine state. */
+        State?: string,
+        /** The virtual machine ID. */
+        VmId?: string,
+    }
+
+    interface VmStartupScriptConfiguration {
+        /** Optional port requests (name/protocol) that will be used by the VmStartupScript. Max of 5 requests. */
+        PortRequests?: VmStartupScriptPortRequest[],
+        /** Asset which contains the VmStartupScript script and any other required files. */
+        VmStartupScriptAssetReference: AssetReference,
+    }
+
+    interface VmStartupScriptParams {
+        /** Optional port requests (name/protocol) that will be used by the VmStartupScript. Max of 5 requests. */
+        PortRequests?: VmStartupScriptPortRequestParams[],
+        /** Asset which contains the VmStartupScript script and any other required files. */
+        VmStartupScriptAssetReference: AssetReferenceParams,
+    }
+
+    interface VmStartupScriptPortRequest {
+        /** The name for the port. */
+        Name: string,
+        /** The protocol for the port. */
+        Protocol: ProtocolType,
+    }
+
+    interface VmStartupScriptPortRequestParams {
+        /** The name for the port. */
+        Name: string,
+        /** The protocol for the port. */
+        Protocol: ProtocolType,
+    }
+
+    interface WindowsCrashDumpConfiguration {
+        /** See https://docs.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps for valid values. */
+        CustomDumpFlags?: number,
+        /** See https://docs.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps for valid values. */
+        DumpType?: number,
+        /** Designates whether automatic crash dump capturing will be enabled for this Build. */
+        IsEnabled: boolean,
+    }
+
+}
+
+/** Multiplayer interface methods (includes Matchmaking, MultiplayerServer, Party, and Lobby) */
+interface IPlayFabMultiplayerAPI {
+    /**
+     * Cancel all active tickets the player is a member of in a given queue.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/matchmaking/cancelallmatchmakingticketsforplayer
+     */
+    CancelAllMatchmakingTicketsForPlayer(request: PlayFabMultiplayerModels.CancelAllMatchmakingTicketsForPlayerRequest): PlayFabMultiplayerModels.CancelAllMatchmakingTicketsForPlayerResult;
+
+    /**
+     * Cancel all active backfill tickets the player is a member of in a given queue.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/matchmaking/cancelallserverbackfillticketsforplayer
+     */
+    CancelAllServerBackfillTicketsForPlayer(request: PlayFabMultiplayerModels.CancelAllServerBackfillTicketsForPlayerRequest): PlayFabMultiplayerModels.CancelAllServerBackfillTicketsForPlayerResult;
+
+    /**
+     * Cancel a matchmaking ticket.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/matchmaking/cancelmatchmakingticket
+     */
+    CancelMatchmakingTicket(request: PlayFabMultiplayerModels.CancelMatchmakingTicketRequest): PlayFabMultiplayerModels.CancelMatchmakingTicketResult;
+
+    /**
+     * Cancel a server backfill ticket.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/matchmaking/cancelserverbackfillticket
+     */
+    CancelServerBackfillTicket(request: PlayFabMultiplayerModels.CancelServerBackfillTicketRequest): PlayFabMultiplayerModels.CancelServerBackfillTicketResult;
+
+    /**
+     * Creates a multiplayer server build alias.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/createbuildalias
+     */
+    CreateBuildAlias(request: PlayFabMultiplayerModels.CreateBuildAliasRequest): PlayFabMultiplayerModels.BuildAliasDetailsResponse;
+
+    /**
+     * Creates a multiplayer server build with a custom container.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/createbuildwithcustomcontainer
+     */
+    CreateBuildWithCustomContainer(request: PlayFabMultiplayerModels.CreateBuildWithCustomContainerRequest): PlayFabMultiplayerModels.CreateBuildWithCustomContainerResponse;
+
+    /**
+     * Creates a multiplayer server build with a managed container.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/createbuildwithmanagedcontainer
+     */
+    CreateBuildWithManagedContainer(request: PlayFabMultiplayerModels.CreateBuildWithManagedContainerRequest): PlayFabMultiplayerModels.CreateBuildWithManagedContainerResponse;
+
+    /**
+     * Creates a multiplayer server build with the server running as a process.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/createbuildwithprocessbasedserver
+     */
+    CreateBuildWithProcessBasedServer(request: PlayFabMultiplayerModels.CreateBuildWithProcessBasedServerRequest): PlayFabMultiplayerModels.CreateBuildWithProcessBasedServerResponse;
+
+    /**
+     * Create a lobby.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/lobby/createlobby
+     */
+    CreateLobby(request: PlayFabMultiplayerModels.CreateLobbyRequest): PlayFabMultiplayerModels.CreateLobbyResult;
+
+    /**
+     * Create a matchmaking ticket as a client.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/matchmaking/creatematchmakingticket
+     */
+    CreateMatchmakingTicket(request: PlayFabMultiplayerModels.CreateMatchmakingTicketRequest): PlayFabMultiplayerModels.CreateMatchmakingTicketResult;
+
+    /**
+     * Creates a remote user to log on to a VM for a multiplayer server build.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/createremoteuser
+     */
+    CreateRemoteUser(request: PlayFabMultiplayerModels.CreateRemoteUserRequest): PlayFabMultiplayerModels.CreateRemoteUserResponse;
+
+    /**
+     * Create a backfill matchmaking ticket as a server. A backfill ticket represents an ongoing game. The matchmaking service
+     * automatically starts matching the backfill ticket against other matchmaking tickets. Backfill tickets cannot match with
+     * other backfill tickets.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/matchmaking/createserverbackfillticket
+     */
+    CreateServerBackfillTicket(request: PlayFabMultiplayerModels.CreateServerBackfillTicketRequest): PlayFabMultiplayerModels.CreateServerBackfillTicketResult;
+
+    /**
+     * Create a matchmaking ticket as a server. The matchmaking service automatically starts matching the ticket against other
+     * matchmaking tickets.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/matchmaking/createservermatchmakingticket
+     */
+    CreateServerMatchmakingTicket(request: PlayFabMultiplayerModels.CreateServerMatchmakingTicketRequest): PlayFabMultiplayerModels.CreateMatchmakingTicketResult;
+
+    /**
+     * Creates a request to change a title's multiplayer server quotas.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/createtitlemultiplayerserversquotachange
+     */
+    CreateTitleMultiplayerServersQuotaChange(request: PlayFabMultiplayerModels.CreateTitleMultiplayerServersQuotaChangeRequest): PlayFabMultiplayerModels.CreateTitleMultiplayerServersQuotaChangeResponse;
+
+    /**
+     * Deletes a multiplayer server game asset for a title.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/deleteasset
+     */
+    DeleteAsset(request: PlayFabMultiplayerModels.DeleteAssetRequest): PlayFabMultiplayerModels.EmptyResponse;
+
+    /**
+     * Deletes a multiplayer server build.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/deletebuild
+     */
+    DeleteBuild(request: PlayFabMultiplayerModels.DeleteBuildRequest): PlayFabMultiplayerModels.EmptyResponse;
+
+    /**
+     * Deletes a multiplayer server build alias.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/deletebuildalias
+     */
+    DeleteBuildAlias(request: PlayFabMultiplayerModels.DeleteBuildAliasRequest): PlayFabMultiplayerModels.EmptyResponse;
+
+    /**
+     * Removes a multiplayer server build's region.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/deletebuildregion
+     */
+    DeleteBuildRegion(request: PlayFabMultiplayerModels.DeleteBuildRegionRequest): PlayFabMultiplayerModels.EmptyResponse;
+
+    /**
+     * Deletes a multiplayer server game certificate.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/deletecertificate
+     */
+    DeleteCertificate(request: PlayFabMultiplayerModels.DeleteCertificateRequest): PlayFabMultiplayerModels.EmptyResponse;
+
+    /**
+     * Deletes a container image repository.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/deletecontainerimagerepository
+     */
+    DeleteContainerImageRepository(request: PlayFabMultiplayerModels.DeleteContainerImageRequest): PlayFabMultiplayerModels.EmptyResponse;
+
+    /**
+     * Delete a lobby.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/lobby/deletelobby
+     */
+    DeleteLobby(request: PlayFabMultiplayerModels.DeleteLobbyRequest): PlayFabMultiplayerModels.LobbyEmptyResult;
+
+    /**
+     * Deletes a remote user to log on to a VM for a multiplayer server build.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/deleteremoteuser
+     */
+    DeleteRemoteUser(request: PlayFabMultiplayerModels.DeleteRemoteUserRequest): PlayFabMultiplayerModels.EmptyResponse;
+
+    /**
+     * Deletes a multiplayer server game secret.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/deletesecret
+     */
+    DeleteSecret(request: PlayFabMultiplayerModels.DeleteSecretRequest): PlayFabMultiplayerModels.EmptyResponse;
+
+    /**
+     * Enables the multiplayer server feature for a title.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/enablemultiplayerserversfortitle
+     */
+    EnableMultiplayerServersForTitle(request: PlayFabMultiplayerModels.EnableMultiplayerServersForTitleRequest): PlayFabMultiplayerModels.EnableMultiplayerServersForTitleResponse;
+
+    /**
+     * Find lobbies which match certain criteria, and which friends are in.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/lobby/findfriendlobbies
+     */
+    FindFriendLobbies(request: PlayFabMultiplayerModels.FindFriendLobbiesRequest): PlayFabMultiplayerModels.FindFriendLobbiesResult;
+
+    /**
+     * Find all the lobbies that match certain criteria.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/lobby/findlobbies
+     */
+    FindLobbies(request: PlayFabMultiplayerModels.FindLobbiesRequest): PlayFabMultiplayerModels.FindLobbiesResult;
+
+    /**
+     * Gets a URL that can be used to download the specified asset. A sample pre-authenticated url -
+     * https://sampleStorageAccount.blob.core.windows.net/gameassets/gameserver.zip?sv=2015-04-05&ss=b&srt=sco&sp=rw&st=startDate&se=endDate&spr=https&sig=sampleSig&api-version=2017-07-29
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/getassetdownloadurl
+     */
+    GetAssetDownloadUrl(request: PlayFabMultiplayerModels.GetAssetDownloadUrlRequest): PlayFabMultiplayerModels.GetAssetDownloadUrlResponse;
+
+    /**
+     * Gets the URL to upload assets to. A sample pre-authenticated url -
+     * https://sampleStorageAccount.blob.core.windows.net/gameassets/gameserver.zip?sv=2015-04-05&ss=b&srt=sco&sp=rw&st=startDate&se=endDate&spr=https&sig=sampleSig&api-version=2017-07-29
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/getassetuploadurl
+     */
+    GetAssetUploadUrl(request: PlayFabMultiplayerModels.GetAssetUploadUrlRequest): PlayFabMultiplayerModels.GetAssetUploadUrlResponse;
+
+    /**
+     * Gets a multiplayer server build.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/getbuild
+     */
+    GetBuild(request: PlayFabMultiplayerModels.GetBuildRequest): PlayFabMultiplayerModels.GetBuildResponse;
+
+    /**
+     * Gets a multiplayer server build alias.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/getbuildalias
+     */
+    GetBuildAlias(request: PlayFabMultiplayerModels.GetBuildAliasRequest): PlayFabMultiplayerModels.BuildAliasDetailsResponse;
+
+    /**
+     * Gets the credentials to the container registry.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/getcontainerregistrycredentials
+     */
+    GetContainerRegistryCredentials(request: PlayFabMultiplayerModels.GetContainerRegistryCredentialsRequest): PlayFabMultiplayerModels.GetContainerRegistryCredentialsResponse;
+
+    /**
+     * Get a lobby.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/lobby/getlobby
+     */
+    GetLobby(request: PlayFabMultiplayerModels.GetLobbyRequest): PlayFabMultiplayerModels.GetLobbyResult;
+
+    /**
+     * Get a match.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/matchmaking/getmatch
+     */
+    GetMatch(request: PlayFabMultiplayerModels.GetMatchRequest): PlayFabMultiplayerModels.GetMatchResult;
+
+    /**
+     * SDK support is limited to C# and Java for this API. Get a matchmaking queue configuration.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/matchmaking-admin/getmatchmakingqueue
+     */
+    GetMatchmakingQueue(request: PlayFabMultiplayerModels.GetMatchmakingQueueRequest): PlayFabMultiplayerModels.GetMatchmakingQueueResult;
+
+    /**
+     * Get a matchmaking ticket by ticket Id.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/matchmaking/getmatchmakingticket
+     */
+    GetMatchmakingTicket(request: PlayFabMultiplayerModels.GetMatchmakingTicketRequest): PlayFabMultiplayerModels.GetMatchmakingTicketResult;
+
+    /**
+     * Gets multiplayer server session details for a build.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/getmultiplayerserverdetails
+     */
+    GetMultiplayerServerDetails(request: PlayFabMultiplayerModels.GetMultiplayerServerDetailsRequest): PlayFabMultiplayerModels.GetMultiplayerServerDetailsResponse;
+
+    /**
+     * Gets multiplayer server logs after a server has terminated.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/getmultiplayerserverlogs
+     */
+    GetMultiplayerServerLogs(request: PlayFabMultiplayerModels.GetMultiplayerServerLogsRequest): PlayFabMultiplayerModels.GetMultiplayerServerLogsResponse;
+
+    /**
+     * Gets multiplayer server logs after a server has terminated.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/getmultiplayersessionlogsbysessionid
+     */
+    GetMultiplayerSessionLogsBySessionId(request: PlayFabMultiplayerModels.GetMultiplayerSessionLogsBySessionIdRequest): PlayFabMultiplayerModels.GetMultiplayerServerLogsResponse;
+
+    /**
+     * Get the statistics for a queue.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/matchmaking/getqueuestatistics
+     */
+    GetQueueStatistics(request: PlayFabMultiplayerModels.GetQueueStatisticsRequest): PlayFabMultiplayerModels.GetQueueStatisticsResult;
+
+    /**
+     * Gets a remote login endpoint to a VM that is hosting a multiplayer server build.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/getremoteloginendpoint
+     */
+    GetRemoteLoginEndpoint(request: PlayFabMultiplayerModels.GetRemoteLoginEndpointRequest): PlayFabMultiplayerModels.GetRemoteLoginEndpointResponse;
+
+    /**
+     * Get a matchmaking backfill ticket by ticket Id.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/matchmaking/getserverbackfillticket
+     */
+    GetServerBackfillTicket(request: PlayFabMultiplayerModels.GetServerBackfillTicketRequest): PlayFabMultiplayerModels.GetServerBackfillTicketResult;
+
+    /**
+     * Gets the status of whether a title is enabled for the multiplayer server feature.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/gettitleenabledformultiplayerserversstatus
+     */
+    GetTitleEnabledForMultiplayerServersStatus(request: PlayFabMultiplayerModels.GetTitleEnabledForMultiplayerServersStatusRequest): PlayFabMultiplayerModels.GetTitleEnabledForMultiplayerServersStatusResponse;
+
+    /**
+     * Gets a title's server quota change request.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/gettitlemultiplayerserversquotachange
+     */
+    GetTitleMultiplayerServersQuotaChange(request: PlayFabMultiplayerModels.GetTitleMultiplayerServersQuotaChangeRequest): PlayFabMultiplayerModels.GetTitleMultiplayerServersQuotaChangeResponse;
+
+    /**
+     * Gets the quotas for a title in relation to multiplayer servers.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/gettitlemultiplayerserversquotas
+     */
+    GetTitleMultiplayerServersQuotas(request: PlayFabMultiplayerModels.GetTitleMultiplayerServersQuotasRequest): PlayFabMultiplayerModels.GetTitleMultiplayerServersQuotasResponse;
+
+    /**
+     * Send a notification to invite a player to a lobby.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/lobby/invitetolobby
+     */
+    InviteToLobby(request: PlayFabMultiplayerModels.InviteToLobbyRequest): PlayFabMultiplayerModels.LobbyEmptyResult;
+
+    /**
+     * Join an Arranged lobby.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/lobby/joinarrangedlobby
+     */
+    JoinArrangedLobby(request: PlayFabMultiplayerModels.JoinArrangedLobbyRequest): PlayFabMultiplayerModels.JoinLobbyResult;
+
+    /**
+     * Join a lobby.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/lobby/joinlobby
+     */
+    JoinLobby(request: PlayFabMultiplayerModels.JoinLobbyRequest): PlayFabMultiplayerModels.JoinLobbyResult;
+
+    /**
+     * Preview: Join a lobby as a server entity. This is restricted to client lobbies which are using connections.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/lobby/joinlobbyasserver
+     */
+    JoinLobbyAsServer(request: PlayFabMultiplayerModels.JoinLobbyAsServerRequest): PlayFabMultiplayerModels.JoinLobbyAsServerResult;
+
+    /**
+     * Join a matchmaking ticket.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/matchmaking/joinmatchmakingticket
+     */
+    JoinMatchmakingTicket(request: PlayFabMultiplayerModels.JoinMatchmakingTicketRequest): PlayFabMultiplayerModels.JoinMatchmakingTicketResult;
+
+    /**
+     * Leave a lobby.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/lobby/leavelobby
+     */
+    LeaveLobby(request: PlayFabMultiplayerModels.LeaveLobbyRequest): PlayFabMultiplayerModels.LobbyEmptyResult;
+
+    /**
+     * Preview: Request for server to leave a lobby. This is restricted to client owned lobbies which are using connections.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/lobby/leavelobbyasserver
+     */
+    LeaveLobbyAsServer(request: PlayFabMultiplayerModels.LeaveLobbyAsServerRequest): PlayFabMultiplayerModels.LobbyEmptyResult;
+
+    /**
+     * Lists archived multiplayer server sessions for a build.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/listarchivedmultiplayerservers
+     */
+    ListArchivedMultiplayerServers(request: PlayFabMultiplayerModels.ListMultiplayerServersRequest): PlayFabMultiplayerModels.ListMultiplayerServersResponse;
+
+    /**
+     * Lists multiplayer server game assets for a title.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/listassetsummaries
+     */
+    ListAssetSummaries(request: PlayFabMultiplayerModels.ListAssetSummariesRequest): PlayFabMultiplayerModels.ListAssetSummariesResponse;
+
+    /**
+     * Lists details of all build aliases for a title. Accepts tokens for title and if game client access is enabled, allows
+     * game client to request list of builds with player entity token.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/listbuildaliases
+     */
+    ListBuildAliases(request: PlayFabMultiplayerModels.ListBuildAliasesRequest): PlayFabMultiplayerModels.ListBuildAliasesResponse;
+
+    /**
+     * Lists summarized details of all multiplayer server builds for a title. Accepts tokens for title and if game client
+     * access is enabled, allows game client to request list of builds with player entity token.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/listbuildsummariesv2
+     */
+    ListBuildSummariesV2(request: PlayFabMultiplayerModels.ListBuildSummariesRequest): PlayFabMultiplayerModels.ListBuildSummariesResponse;
+
+    /**
+     * Lists multiplayer server game certificates for a title.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/listcertificatesummaries
+     */
+    ListCertificateSummaries(request: PlayFabMultiplayerModels.ListCertificateSummariesRequest): PlayFabMultiplayerModels.ListCertificateSummariesResponse;
+
+    /**
+     * Lists custom container images for a title.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/listcontainerimages
+     */
+    ListContainerImages(request: PlayFabMultiplayerModels.ListContainerImagesRequest): PlayFabMultiplayerModels.ListContainerImagesResponse;
+
+    /**
+     * Lists the tags for a custom container image.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/listcontainerimagetags
+     */
+    ListContainerImageTags(request: PlayFabMultiplayerModels.ListContainerImageTagsRequest): PlayFabMultiplayerModels.ListContainerImageTagsResponse;
+
+    /**
+     * SDK support is limited to C# and Java for this API. List all matchmaking queue configs.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/matchmaking-admin/listmatchmakingqueues
+     */
+    ListMatchmakingQueues(request: PlayFabMultiplayerModels.ListMatchmakingQueuesRequest): PlayFabMultiplayerModels.ListMatchmakingQueuesResult;
+
+    /**
+     * List all matchmaking ticket Ids the user is a member of.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/matchmaking/listmatchmakingticketsforplayer
+     */
+    ListMatchmakingTicketsForPlayer(request: PlayFabMultiplayerModels.ListMatchmakingTicketsForPlayerRequest): PlayFabMultiplayerModels.ListMatchmakingTicketsForPlayerResult;
+
+    /**
+     * Lists multiplayer server sessions for a build.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/listmultiplayerservers
+     */
+    ListMultiplayerServers(request: PlayFabMultiplayerModels.ListMultiplayerServersRequest): PlayFabMultiplayerModels.ListMultiplayerServersResponse;
+
+    /**
+     * Lists quality of service servers for party.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/listpartyqosservers
+     */
+    ListPartyQosServers(request: PlayFabMultiplayerModels.ListPartyQosServersRequest): PlayFabMultiplayerModels.ListPartyQosServersResponse;
+
+    /**
+     * Lists quality of service servers for the title. By default, servers are only returned for regions where a Multiplayer
+     * Servers build has been deployed.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/listqosserversfortitle
+     */
+    ListQosServersForTitle(request: PlayFabMultiplayerModels.ListQosServersForTitleRequest): PlayFabMultiplayerModels.ListQosServersForTitleResponse;
+
+    /**
+     * Lists multiplayer server game secrets for a title.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/listsecretsummaries
+     */
+    ListSecretSummaries(request: PlayFabMultiplayerModels.ListSecretSummariesRequest): PlayFabMultiplayerModels.ListSecretSummariesResponse;
+
+    /**
+     * List all server backfill ticket Ids the user is a member of.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/matchmaking/listserverbackfillticketsforplayer
+     */
+    ListServerBackfillTicketsForPlayer(request: PlayFabMultiplayerModels.ListServerBackfillTicketsForPlayerRequest): PlayFabMultiplayerModels.ListServerBackfillTicketsForPlayerResult;
+
+    /**
+     * List all server quota change requests for a title.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/listtitlemultiplayerserversquotachanges
+     */
+    ListTitleMultiplayerServersQuotaChanges(request: PlayFabMultiplayerModels.ListTitleMultiplayerServersQuotaChangesRequest): PlayFabMultiplayerModels.ListTitleMultiplayerServersQuotaChangesResponse;
+
+    /**
+     * Lists virtual machines for a title.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/listvirtualmachinesummaries
+     */
+    ListVirtualMachineSummaries(request: PlayFabMultiplayerModels.ListVirtualMachineSummariesRequest): PlayFabMultiplayerModels.ListVirtualMachineSummariesResponse;
+
+    /**
+     * SDK support is limited to C# and Java for this API. Remove a matchmaking queue config.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/matchmaking-admin/removematchmakingqueue
+     */
+    RemoveMatchmakingQueue(request: PlayFabMultiplayerModels.RemoveMatchmakingQueueRequest): PlayFabMultiplayerModels.RemoveMatchmakingQueueResult;
+
+    /**
+     * Remove a member from a lobby.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/lobby/removemember
+     */
+    RemoveMember(request: PlayFabMultiplayerModels.RemoveMemberFromLobbyRequest): PlayFabMultiplayerModels.LobbyEmptyResult;
+
+    /**
+     * Request a multiplayer server session. Accepts tokens for title and if game client access is enabled, allows game client
+     * to request a server with player entity token.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/requestmultiplayerserver
+     */
+    RequestMultiplayerServer(request: PlayFabMultiplayerModels.RequestMultiplayerServerRequest): PlayFabMultiplayerModels.RequestMultiplayerServerResponse;
+
+    /**
+     * Request a party session.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/requestpartyservice
+     */
+    RequestPartyService(request: PlayFabMultiplayerModels.RequestPartyServiceRequest): PlayFabMultiplayerModels.RequestPartyServiceResponse;
+
+    /**
+     * Rolls over the credentials to the container registry.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/rollovercontainerregistrycredentials
+     */
+    RolloverContainerRegistryCredentials(request: PlayFabMultiplayerModels.RolloverContainerRegistryCredentialsRequest): PlayFabMultiplayerModels.RolloverContainerRegistryCredentialsResponse;
+
+    /**
+     * SDK support is limited to C# and Java for this API. Create or update a matchmaking queue configuration.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/matchmaking-admin/setmatchmakingqueue
+     */
+    SetMatchmakingQueue(request: PlayFabMultiplayerModels.SetMatchmakingQueueRequest): PlayFabMultiplayerModels.SetMatchmakingQueueResult;
+
+    /**
+     * Shuts down a multiplayer server session.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/shutdownmultiplayerserver
+     */
+    ShutdownMultiplayerServer(request: PlayFabMultiplayerModels.ShutdownMultiplayerServerRequest): PlayFabMultiplayerModels.EmptyResponse;
+
+    /**
+     * Subscribe to lobby resource notifications.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/lobby/subscribetolobbyresource
+     */
+    SubscribeToLobbyResource(request: PlayFabMultiplayerModels.SubscribeToLobbyResourceRequest): PlayFabMultiplayerModels.SubscribeToLobbyResourceResult;
+
+    /**
+     * Subscribe to match resource notifications.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/matchmaking/subscribetomatchmakingresource
+     */
+    SubscribeToMatchmakingResource(request: PlayFabMultiplayerModels.SubscribeToMatchResourceRequest): PlayFabMultiplayerModels.SubscribeToMatchResourceResult;
+
+    /**
+     * Unsubscribe from lobby notifications.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/lobby/unsubscribefromlobbyresource
+     */
+    UnsubscribeFromLobbyResource(request: PlayFabMultiplayerModels.UnsubscribeFromLobbyResourceRequest): PlayFabMultiplayerModels.LobbyEmptyResult;
+
+    /**
+     * Unsubscribe from match resource notifications.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/matchmaking/unsubscribefrommatchmakingresource
+     */
+    UnsubscribeFromMatchmakingResource(request: PlayFabMultiplayerModels.UnsubscribeFromMatchResourceRequest): PlayFabMultiplayerModels.UnsubscribeFromMatchResourceResult;
+
+    /**
+     * Untags a container image.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/untagcontainerimage
+     */
+    UntagContainerImage(request: PlayFabMultiplayerModels.UntagContainerImageRequest): PlayFabMultiplayerModels.EmptyResponse;
+
+    /**
+     * Creates a multiplayer server build alias.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/updatebuildalias
+     */
+    UpdateBuildAlias(request: PlayFabMultiplayerModels.UpdateBuildAliasRequest): PlayFabMultiplayerModels.BuildAliasDetailsResponse;
+
+    /**
+     * Updates a multiplayer server build's name.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/updatebuildname
+     */
+    UpdateBuildName(request: PlayFabMultiplayerModels.UpdateBuildNameRequest): PlayFabMultiplayerModels.EmptyResponse;
+
+    /**
+     * Updates a multiplayer server build's region. If the region is not yet created, it will be created
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/updatebuildregion
+     */
+    UpdateBuildRegion(request: PlayFabMultiplayerModels.UpdateBuildRegionRequest): PlayFabMultiplayerModels.EmptyResponse;
+
+    /**
+     * Updates a multiplayer server build's regions.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/updatebuildregions
+     */
+    UpdateBuildRegions(request: PlayFabMultiplayerModels.UpdateBuildRegionsRequest): PlayFabMultiplayerModels.EmptyResponse;
+
+    /**
+     * Update a lobby.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/lobby/updatelobby
+     */
+    UpdateLobby(request: PlayFabMultiplayerModels.UpdateLobbyRequest): PlayFabMultiplayerModels.LobbyEmptyResult;
+
+    /**
+     * Preview: Update fields related to a joined server in the lobby the server is in. Servers can keep a lobby from expiring
+     * by being the one to "update" the lobby in some way. Servers have no impact on last member leave/last member disconnect
+     * behavior.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/lobby/updatelobbyasserver
+     */
+    UpdateLobbyAsServer(request: PlayFabMultiplayerModels.UpdateLobbyAsServerRequest): PlayFabMultiplayerModels.LobbyEmptyResult;
+
+    /**
+     * Uploads a multiplayer server game certificate.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/uploadcertificate
+     */
+    UploadCertificate(request: PlayFabMultiplayerModels.UploadCertificateRequest): PlayFabMultiplayerModels.EmptyResponse;
+
+    /**
+     * Uploads a multiplayer server game secret.
+     * https://docs.microsoft.com/rest/api/playfab/multiplayer/multiplayerserver/uploadsecret
+     */
+    UploadSecret(request: PlayFabMultiplayerModels.UploadSecretRequest): PlayFabMultiplayerModels.EmptyResponse;
 
 
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playfab-cloudscriptexample",
-  "version": "0.0.220509",
+  "version": "0.0.260227",
   "description": "PlayFab CloudScriptExample",
   "main": "ExampleCloudScript.js",
   "author": {


### PR DESCRIPTION
Regenerates the CloudScript TypeScript typings from the latest PlayFab API specs using SDKGenerator. This repo was last updated in May 2022, so this PR brings ~4 years of API changes forward, plus adds the new multiplayer global typings.

**Summary of Changes to individual files**
  - For CloudScript.d.ts:
     - New: declare var multiplayer: IPlayFabMultiplayerAPI -> typed access to Matchmaking, MultiplayerServer, Party, and Lobby
    APIs (e.g., CreateMatchmakingTicket, GetMatch, JoinMatchmakingTicket, ListMatchmakingTicketsForPlayer). Related PR here: https://github.com/PlayFab/SDKGenerator/pull/904
     - New: PlayFabMultiplayerModels namespace -> all request/response interfaces and enums for the Multiplayer API
     - New: IPlayFabMultiplayerAPI interface -> full method signatures with typed parameters and return values
     - Updated: IPlayFabServerAPI -> reflects ~4 years of Server API additions, removals, and model changes
     - Updated: IPlayFabEntityAPI -> reflects additions to Authentication, Data, Events, Groups, and Profiles APIs
     - Updated: Error code enum -> new error codes added since 2022

  - package.json
     - Version bumped by the generator to match current SDK version